### PR TITLE
ci: drop deprecated k8s

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HELM_DOCS_VERSION="0.11.0"
+HELM_DOCS_VERSION="0.13.0"
 
 # install helm-docs
 curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
-KUBEVAL_VERSION="0.14.0"
+KUBEVAL_VERSION="0.15.0"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"
 
 # install kubeval

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,12 +34,11 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.12.10
-          - v1.13.12
           - v1.14.10
-          - v1.15.11
-          - v1.16.8
+          - v1.15.7
+          - v1.16.4
           - v1.17.4
+          - v1.18.1
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -58,12 +57,11 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.12.10
-          - v1.13.12
           - v1.14.10
-          - v1.15.7
-          - v1.16.4
-          - v1.17.2
+          - v1.15.11
+          - v1.16.9
+          - v1.17.5
+          - v1.18.4
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
k8s 0.12.x and 0.13.x have now been dropped by AWS, Azure, and GCP