### PR TITLE
Propagate "envFrom" property to CronJob

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+set -x
+
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
 KUBEVAL_VERSION="0.15.0"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-set -x
-
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
 KUBEVAL_VERSION="0.15.0"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: '23.10.1'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '23.10.1'
+version: '23.10.1+1'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.labels | object | `{}` |  |
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |
+| envFrom | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"23.10.1"` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -2,7 +2,7 @@ renovate
 ========
 Universal dependency update tool that fits into your workflows.
 
-Current chart version is `23.10.1`
+Current chart version is `23.10.1+1`
 
 Source code can be found [here](https://github.com/renovatebot/renovate)
 

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -53,12 +53,16 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- with .Values.envFrom }}
+              envFrom:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
               volumeMounts:
               - name: config-volume
                 mountPath: /usr/src/app/config.json
                 subPath: config.json
               resources:
-  {{ toYaml .Values.resources | indent 14 }}
+  {{ toYaml .Values.resources | indent 16 }}
     {{- with .Values.nodeSelector }}
           nodeSelector:
 {{ toYaml . | indent 12 }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -61,7 +61,7 @@ spec:
                 subPath: config.json
               {{- if or .Values.secrets .Values.envFrom }}
               envFrom:
-                {{- if or .Values.secrets }}
+                {{- if .Values.secrets }}
                 - secretRef:
                     name: {{ $fullName }}-secret
                 {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -59,7 +59,7 @@ spec:
               - name: config-volume
                 mountPath: /usr/src/app/config.json
                 subPath: config.json
-              {{- if .Values.secrets or .Values.envFrom }}
+              {{- if or .Values.secrets .Values.envFrom }}
               envFrom:
                 - secretRef:
                     name: {{ $fullName }}-secret

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -55,18 +55,17 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-            {{- with .Values.envFrom }}
-              envFrom:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
               volumeMounts:
               - name: config-volume
                 mountPath: /usr/src/app/config.json
                 subPath: config.json
-              {{- if .Values.secrets }}
+              {{- if .Values.secrets or .Values.envFrom }}
               envFrom:
                 - secretRef:
                     name: {{ $fullName }}-secret
+                {{- with .Values.envFrom }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
               {{- end }}
               resources:
   {{ toYaml .Values.resources | indent 14 }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -61,8 +61,10 @@ spec:
                 subPath: config.json
               {{- if or .Values.secrets .Values.envFrom }}
               envFrom:
+                {{- if or .Values.secrets }}
                 - secretRef:
                     name: {{ $fullName }}-secret
+                {{- end }}
                 {{- with .Values.envFrom }}
                   {{- toYaml . | nindent 16 }}
                 {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -62,7 +62,7 @@ spec:
                 mountPath: /usr/src/app/config.json
                 subPath: config.json
               resources:
-  {{ toYaml .Values.resources | indent 16 }}
+  {{ toYaml .Values.resources | indent 14 }}
     {{- with .Values.nodeSelector }}
           nodeSelector:
 {{ toYaml . | indent 12 }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -32,4 +32,4 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
-envFrom: {}
+envFrom: []

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -31,3 +31,5 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+envFrom: {}


### PR DESCRIPTION
Existing "secrets" property provides a limited and unsecure way to pass sensitive values to the cron job.

Proposed change allows a user to provide arbitrary secrets\configmaps that are injected as environment variables into the pod.