### PR TITLE
Allow existing secret

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HELM_DOCS_VERSION="0.13.0"
+HELM_DOCS_VERSION="0.15.0"
 
 # install helm-docs
 curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz

--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 HELM_DOCS_VERSION="0.15.0"
 

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
+echo "$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts)"
+
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
 KUBEVAL_VERSION="0.15.0"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-echo "$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts)"
-
-CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
+CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | cut -d '/' -f 2 | uniq)"
 KUBEVAL_VERSION="0.15.0"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"
 
@@ -13,5 +11,5 @@ tar -xf /tmp/kubeval.tar.gz kubeval
 
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
-  helm template --values "${CHART_DIR}"/ci/ci-values.yaml "${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
+  helm template --values charts/"${CHART_DIR}"/ci/ci-values.yaml charts/"${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
 done

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
 KUBEVAL_VERSION="0.15.0"

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,10 +1,10 @@
-renovate
-========
+# renovate
+
 Universal dependency update tool that fits into your workflows.
 
 Current chart version is `23.26.1`
 
-Source code can be found [here](https://github.com/renovatebot/renovate)
+**Homepage:** <https://github.com/renovatebot/renovate>
 
 ## Installation
 
@@ -35,7 +35,7 @@ helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' renov
 
 The following table lists the configurable parameters of the chart and the default values.
 
-## Chart Values
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |
 | envFrom | list | `[]` |  |
+| existingSecret | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"23.26.1"` |  |
@@ -55,3 +56,6 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.config | string | `""` |  |
 | resources | object | `{}` |  |
 | secrets | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -3,7 +3,7 @@
 
 {{ template "chart.versionLine" . }}
 
-{{ template "chart.sourceLinkLine" . }}
+{{ template "chart.homepageLine" . }}
 
 ## Installation
 

--- a/charts/renovate/templates/_helpers.tpl
+++ b/charts/renovate/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define secret names
+*/}}
+{{- define "renovate.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{- .Values.existingSecret -}}
+{{- else -}}
+{{ include "renovate.fullname" . }}-secret
+{{- end -}}
+{{- end -}}

--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "renovate.fullname" . }}-config
   labels:
-    app: {{ template "renovate.name" . }}
-    chart: {{ template "renovate.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "renovate.labels" . | nindent 4 }}
 data:
   config.json: |-
     {{ required "A valid .Values.renovate.config entry is required!" .Values.renovate.config | nindent 4 }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -39,10 +39,7 @@ spec:
             {{ toYaml .Values.pod.annotations | nindent 12 }}
 {{- end }}
         spec:
-          volumes:
-            - name: config-volume
-              configMap:
-                name: {{ $fullName }}-config
+          serviceAccountName: {{ include "renovate.serviceAccountName" . }}
           restartPolicy: {{ .Values.cronjob.jobRestartPolicy }}
           containers:
             - name: {{ .Chart.Name }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -1,20 +1,15 @@
-{{- $fullName := include "renovate.fullname" . -}}
-{{- $name := include "renovate.name" . -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "renovate.fullname" . }}
   labels:
-    app: {{ $name }}
-    chart: {{ template "renovate.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-{{- if .Values.cronjob.labels }}
-{{ toYaml .Values.cronjob.labels | indent 4 }}
+    {{- include "renovate.labels" . | nindent 4 }}
+  {{- with .Values.cronjob.labels }}
+    {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- if .Values.cronjob.annotations }}
   annotations:
-{{ toYaml .Values.cronjob.annotations | indent 4 }}
+    {{ toYaml .Values.cronjob.annotations | nindent 4 }}
 {{- end }}
 spec:
   schedule: "{{ .Values.cronjob.schedule }}"
@@ -30,20 +25,18 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        app: {{ $name }}
-        release: {{ .Release.Name }}
+        {{- include "renovate.selectorLabels" . | nindent 8 }}
     spec:
       template:
         metadata:
           labels:
-            app: {{ $name }}
-            release: {{ .Release.Name }}
-{{- if .Values.pod.labels }}
-{{ toYaml .Values.pod.labels | indent 12 }}
+            {{- include "renovate.selectorLabels" . | nindent 12 }}
+          {{- with .Values.pod.labels }}
+            {{- toYaml . | nindent 12 }}
 {{- end }}
 {{- if .Values.pod.annotations }}
           annotations:
-{{ toYaml .Values.pod.annotations | indent 12 }}
+            {{ toYaml .Values.pod.annotations | nindent 12 }}
 {{- end }}
         spec:
           volumes:
@@ -63,27 +56,31 @@ spec:
               envFrom:
                 {{- if .Values.secrets }}
                 - secretRef:
-                    name: {{ $fullName }}-secret
+                    name: {{ include "renovate.fullname" . }}-secret
                 {{- end }}
                 {{- with .Values.envFrom }}
                   {{- toYaml . | nindent 16 }}
                 {{- end }}
               {{- end }}
               resources:
-  {{ toYaml .Values.resources | indent 14 }}
+                {{ toYaml .Values.resources | nindent 16 }}
+          volumes:
+            - name: config-volume
+              configMap:
+                name: {{ include "renovate.fullname" . }}-config
     {{- with .Values.nodeSelector }}
           nodeSelector:
-{{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
     {{- end }}
     {{- with .Values.affinity }}
           affinity:
-{{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
     {{- end }}
     {{- with .Values.tolerations }}
           tolerations:
-{{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
     {{- end }}
     {{- with .Values.securityContext }}
           securityContext:
-{{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
     {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.cronjob.labels }}
     {{- toYaml . | nindent 4 }}
-{{- end }}
+  {{- end }}
 {{- if .Values.cronjob.annotations }}
   annotations:
     {{ toYaml .Values.cronjob.annotations | nindent 4 }}
@@ -33,11 +33,11 @@ spec:
             {{- include "renovate.selectorLabels" . | nindent 12 }}
           {{- with .Values.pod.labels }}
             {{- toYaml . | nindent 12 }}
-{{- end }}
-{{- if .Values.pod.annotations }}
+          {{- end }}
+        {{- if .Values.pod.annotations }}
           annotations:
             {{ toYaml .Values.pod.annotations | nindent 12 }}
-{{- end }}
+        {{- end }}
         spec:
           serviceAccountName: {{ include "renovate.serviceAccountName" . }}
           restartPolicy: {{ .Values.cronjob.jobRestartPolicy }}
@@ -49,11 +49,11 @@ spec:
               - name: config-volume
                 mountPath: /usr/src/app/config.json
                 subPath: config.json
-              {{- if or .Values.secrets .Values.envFrom }}
+              {{- if or .Values.secrets .Values.existingSecret .Values.envFrom }}
               envFrom:
-                {{- if .Values.secrets }}
+                {{- if or .Values.secrets .Values.existingSecret }}
                 - secretRef:
-                    name: {{ include "renovate.fullname" . }}-secret
+                    name: {{ template "renovate.secretName" . }}
                 {{- end }}
                 {{- with .Values.envFrom }}
                   {{- toYaml . | nindent 16 }}
@@ -65,19 +65,19 @@ spec:
             - name: config-volume
               configMap:
                 name: {{ include "renovate.fullname" . }}-config
-    {{- with .Values.nodeSelector }}
+        {{- with .Values.nodeSelector }}
           nodeSelector:
             {{ toYaml . | nindent 12 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- end }}
+        {{- with .Values.affinity }}
           affinity:
             {{ toYaml . | nindent 12 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- end }}
+        {{- with .Values.tolerations }}
           tolerations:
             {{ toYaml . | nindent 12 }}
-    {{- end }}
-    {{- with .Values.securityContext }}
+        {{- end }}
+        {{- with .Values.securityContext }}
           securityContext:
             {{ toYaml . | nindent 12 }}
-    {{- end }}
+        {{- end }}

--- a/charts/renovate/templates/secret.yaml
+++ b/charts/renovate/templates/secret.yaml
@@ -4,13 +4,10 @@ kind: Secret
 metadata:
   name: {{ template "renovate.fullname" . }}-secret
   labels:
-    app: {{ template "renovate.name" . }}
-    chart: {{ template "renovate.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "renovate.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- range $k, $v := index .Values.secrets }}
-  {{ $k }}: {{- $v | b64enc | indent 2 }}
+  {{ $k }}: {{- $v | b64enc | nindent 2 }}
   {{- end }}
   {{- end }}

--- a/charts/renovate/templates/secret.yaml
+++ b/charts/renovate/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secrets }}
+{{- if and .Values.secrets (not .Values.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +10,4 @@ data:
   {{- range $k, $v := index .Values.secrets }}
   {{ $k }}: {{- $v | b64enc | nindent 2 }}
   {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -19,6 +19,18 @@ image:
 
 renovate:
   config: ''
+  # See https://docs.renovatebot.com/self-hosted-configuration
+  # config: |
+  #   {
+  #     "platform": "gitlab",
+  #     "endpoint": "https://gitlab.example.com/api/v4",
+  #     "token": "your-gitlab-renovate-user-token",
+  #     "autodiscover": "false",
+  #     "dryRun": true,
+  #     "printConfig": true,
+  #     "logLevel": "debug",
+  #     "repositories": ["username/repo", "orgname/repo"]
+  #   }
 
 secrets: {}
 

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -32,7 +32,10 @@ renovate:
   #     "repositories": ["username/repo", "orgname/repo"]
   #   }
 
+# Provide secrets inline
 secrets: {}
+# or provide the name of an existing secret to be read instead.
+existingSecret: ""
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -22,6 +22,15 @@ renovate:
 
 secrets: {}
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
* Allow use of existing secret - defined outside of the helm values.yaml
* Provide example renovate.config value
* Use _helper defined serviceaccountname
* Use nindent to improve readability and the existing _helper defined labels