### PR TITLE
feat: Add support for private custom image

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"23.36.4"` |  |
+| imagePullSecrets | object | `{}` |  |
 | pod.annotations | object | `{}` |  |
 | pod.labels | object | `{}` |  |
 | renovate.config | string | `""` |  |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -81,3 +81,7 @@ spec:
           securityContext:
             {{ toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -17,6 +17,8 @@ image:
   tag: 23.36.4
   pullPolicy: IfNotPresent
 
+imagePullSecrets: {}
+
 renovate:
   config: ''
   # See https://docs.renovatebot.com/self-hosted-configuration


### PR DESCRIPTION
Hey 👋 ,

I need to be able to use my own custom Renovate image (Mostly for injecting a `.nprmc`). A great way to do this would be to be able to use my own image, from my private registry.

To do this, I need to inject an `imagePullSecrets` into the spec of the cronjob. This PR resolves this.

How should I test my changes?

Thanks!