### PR TITLE
feat: add backoffLimit to job spec

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -42,6 +42,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.annotations | object | `{}` |  |
 | cronjob.concurrencyPolicy | string | `""` |  |
 | cronjob.failedJobsHistoryLimit | string | `""` |  |
+| cronjob.jobBackoffLimit | string | `""` |  |
 | cronjob.jobRestartPolicy | string | `"Never"` |  |
 | cronjob.labels | object | `{}` |  |
 | cronjob.schedule | string | `"0 1 * * *"` |  |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
         {{- include "renovate.selectorLabels" . | nindent 8 }}
     spec:
+      backoffLimit: {{ .Values.cronjob.jobBackoffLimit }}
       template:
         metadata:
           labels:

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -7,6 +7,7 @@ cronjob:
   failedJobsHistoryLimit: ''
   successfulJobsHistoryLimit: ''
   jobRestartPolicy: Never
+  jobBackoffLimit: ''
 
 pod:
   annotations: {}


### PR DESCRIPTION
Add `backoffLimit` to Cronjob jobTemplate and a configurable value option.

Relevant Kubernetes documentation: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy