### PR TITLE
feat: allow additional volumes 

### DIFF
--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '25.33.1'
+appVersion: '25.33.2'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '25.33.1'
+version: '25.33.2'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -25,7 +25,7 @@ annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
     - name: renovate
-      image: renovate/renovate:25.33.1
+      image: renovate/renovate:25.33.2
   artifacthub.io/links: |
     - name: docs
       url: https://docs.renovatebot.com

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: '25.56.7'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '25.56.7'
+version: '25.56.7+1'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 25.67.0+1](https://img.shields.io/badge/Version-25.67.0-informational?style=flat-square) ![AppVersion: 25.67.0](https://img.shields.io/badge/AppVersion-25.67.0-informational?style=flat-square)
+![Version: 25.67.0+1](https://img.shields.io/badge/Version-25.67.0+1-informational?style=flat-square) ![AppVersion: 25.67.0](https://img.shields.io/badge/AppVersion-25.67.0-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -55,9 +55,9 @@ The following table lists the configurable parameters of the chart and the defau
 | env | object | `{}` |  |
 | envFrom | list | `[]` |  |
 | existingSecret | string | `""` |  |
-| extraConfigmaps | list | `[]` |  |
-| extraVolumeMounts | list | `[]` |  |
-| extraVolumes | list | `[]` |  |
+| extraConfigmaps | list | `[]` | Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config |
+| extraVolumeMounts | list | `[]` | Additional volumeMounts to the container |
+| extraVolumes | list | `[]` | Additional volumes to the pod |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"25.56.7"` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -50,6 +50,9 @@ The following table lists the configurable parameters of the chart and the defau
 | env | object | `{}` |  |
 | envFrom | list | `[]` |  |
 | existingSecret | string | `""` |  |
+| extraConfigmaps | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"25.33.2"` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 25.33.1](https://img.shields.io/badge/Version-25.33.1-informational?style=flat-square) ![AppVersion: 25.33.1](https://img.shields.io/badge/AppVersion-25.33.1-informational?style=flat-square)
+![Version: 25.33.2](https://img.shields.io/badge/Version-25.33.2-informational?style=flat-square) ![AppVersion: 25.33.2](https://img.shields.io/badge/AppVersion-25.33.2-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the chart and the defau
 | existingSecret | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"renovate/renovate"` |  |
-| image.tag | string | `"25.33.1"` |  |
+| image.tag | string | `"25.33.2"` |  |
 | imagePullSecrets | object | `{}` |  |
 | pod.annotations | object | `{}` |  |
 | pod.labels | object | `{}` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 25.67.0](https://img.shields.io/badge/Version-25.67.0-informational?style=flat-square) ![AppVersion: 25.67.0](https://img.shields.io/badge/AppVersion-25.67.0-informational?style=flat-square)
+![Version: 25.67.0+1](https://img.shields.io/badge/Version-25.67.0-informational?style=flat-square) ![AppVersion: 25.67.0](https://img.shields.io/badge/AppVersion-25.67.0-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -46,7 +46,7 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              {{- if or .Values.renovate.config .Values.ssh_config.enabled }}
+              {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.extraVolumes }}
               volumeMounts:
               {{- if .Values.renovate.config }}
               - name: config-volume
@@ -57,6 +57,9 @@ spec:
               - name: ssh-config-volume
                 mountPath: /home/ubuntu/.ssh
                 readOnly: true
+              {{- end }}
+              {{- if .Values.extraVolumeMounts }}
+                {{- toYaml .Values.extraVolumeMounts | nindent 14 }}
               {{- end }}
               {{- end }}
               {{- if or .Values.redis.enabled .Values.renovate.existingConfigFile .Values.env }}
@@ -85,7 +88,7 @@ spec:
                 {{- end }}
               {{- end }}
               resources:
-                {{ toYaml .Values.resources | nindent 16 }}
+                {{- toYaml .Values.resources | nindent 16 }}
           volumes:
             {{- if .Values.renovate.config }}
             - name: config-volume
@@ -96,6 +99,9 @@ spec:
             - name: ssh-config-volume
               secret:
                 secretName: {{ include "renovate.sshSecretName" .}}
+            {{- end }}
+            {{- if .Values.extraVolumes }}
+              {{- toYaml .Values.extraVolumes | nindent 12 }}
             {{- end }}
         {{- with .Values.nodeSelector }}
           nodeSelector:

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -1,22 +1,22 @@
-{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+  {{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
 apiVersion: batch/v1
   {{- else if .Capabilities.APIVersions.Has "batch/v1beta1/CronJob" }}
 apiVersion: batch/v1beta1
   {{- else }}
-  {{- fail "\n\n ERROR: You must have atleast batch/v1beta1 to use CronJob" }}
+    {{- fail "\n\n ERROR: You must have atleast batch/v1beta1 to use CronJob" }}
   {{- end }}
 kind: CronJob
 metadata:
   name: {{ include "renovate.fullname" . }}
   labels:
-  {{- include "renovate.labels" . | nindent 4 }}
+    {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.cronjob.labels }}
-  {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.cronjob.annotations }}
+{{- if .Values.cronjob.annotations }}
   annotations:
-  {{ toYaml .Values.cronjob.annotations | nindent 4 }}
-  {{- end }}
+    {{ toYaml .Values.cronjob.annotations | nindent 4 }}
+{{- end }}
 spec:
   schedule: "{{ .Values.cronjob.schedule }}"
   {{- with .Values.cronjob.concurrencyPolicy }}
@@ -31,19 +31,19 @@ spec:
   jobTemplate:
     metadata:
       labels:
-    {{- include "renovate.selectorLabels" . | nindent 8 }}
+        {{- include "renovate.selectorLabels" . | nindent 8 }}
     spec:
       backoffLimit: {{ .Values.cronjob.jobBackoffLimit }}
       template:
         metadata:
           labels:
-          {{- include "renovate.selectorLabels" . | nindent 12 }}
+            {{- include "renovate.selectorLabels" . | nindent 12 }}
           {{- with .Values.pod.labels }}
-          {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.pod.annotations }}
+        {{- if .Values.pod.annotations }}
           annotations:
-        {{ toYaml .Values.pod.annotations | nindent 12 }}
+            {{ toYaml .Values.pod.annotations | nindent 12 }}
         {{- end }}
         spec:
           serviceAccountName: {{ include "renovate.serviceAccountName" . }}
@@ -59,26 +59,26 @@ spec:
                   trap "touch /tmp/main-terminated" EXIT
                   while true; do if [[ -f "/tmp/dind-started" ]]; then break; fi; sleep 1; done
                   renovate
-                  {{- end }}
+              {{- end }}
               {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.dind.enabled .Values.extraVolumes }}
               volumeMounts:
-                {{- if .Values.renovate.config }}
-                - name: config-volume
-                  mountPath: /usr/src/app/config.json
-                  subPath: config.json
-                {{- end }}
-                {{- if .Values.ssh_config.enabled }}
-                - name: ssh-config-volume
-                  mountPath: /home/ubuntu/.ssh
-                  readOnly: true
-                  {{- end }}
-                {{- if .Values.extraVolumeMounts }}
-                  {{- toYaml .Values.extraVolumeMounts | nindent 14 }}
-                {{- end }}
-                {{- end }}
-                {{- if .Values.dind.enabled }}
-                - name: {{ .Chart.Name }}-tmp-volume
-                  mountPath: /tmp
+              {{- if .Values.renovate.config }}
+              - name: config-volume
+                mountPath: /usr/src/app/config.json
+                subPath: config.json
+              {{- end }}
+              {{- if .Values.ssh_config.enabled }}
+              - name: ssh-config-volume
+                mountPath: /home/ubuntu/.ssh
+                readOnly: true
+              {{- end }}
+              {{- if .Values.extraVolumeMounts }}
+                {{- toYaml .Values.extraVolumeMounts | nindent 14 }}
+              {{- end }}
+              {{- end }}
+              {{- if .Values.dind.enabled }}
+              - name: {{ .Chart.Name }}-tmp-volume
+                mountPath: /tmp
               {{- end }}
               {{- if or .Values.redis.enabled .Values.renovate.existingConfigFile .Values.env .Values.dind.enabled }}
               env:
@@ -101,20 +101,20 @@ spec:
                   value: "/tmp/certs/client"
                 - name: DOCKER_TLS_VERIFY
                   value: "true"
-              {{- end }}
+                {{- end }}
               {{- end }}
               {{- if or .Values.secrets .Values.existingSecret .Values.envFrom }}
               envFrom:
                 {{- if or .Values.secrets .Values.existingSecret }}
                 - secretRef:
                     name: {{ template "renovate.secretName" . }}
-                  {{- end }}
-                  {{- with .Values.envFrom }}
-                {{- toYaml . | nindent 16 }}
-              {{- end }}
+                {{- end }}
+                {{- with .Values.envFrom }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
               {{- end }}
               resources:
-              {{- toYaml .Values.resources | nindent 16 }}
+                {{- toYaml .Values.resources | nindent 16 }}
             {{- if .Values.dind.enabled }}
             - name: {{ .Chart.Name }}-dind
               image: "{{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}"
@@ -137,7 +137,7 @@ spec:
               volumeMounts:
                 - name: {{ .Chart.Name }}-tmp-volume
                   mountPath: /tmp
-          {{- end }}
+            {{- end }}
           volumes:
             {{- if .Values.renovate.config }}
             - name: config-volume
@@ -152,27 +152,27 @@ spec:
             {{- if .Values.dind.enabled }}
             - name: {{ .Chart.Name }}-tmp-volume
               emptyDir: {}
-              {{- end }}
-              {{- if .Values.extraVolumes }}
-            {{- toYaml .Values.extraVolumes | nindent 12 }}
-          {{- end }}
-          {{- with .Values.nodeSelector }}
+            {{- end }}
+            {{- if .Values.extraVolumes }}
+              {{- toYaml .Values.extraVolumes | nindent 12 }}
+            {{- end }}
+        {{- with .Values.nodeSelector }}
           nodeSelector:
-          {{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.affinity }}
+            {{ toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.affinity }}
           affinity:
-          {{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.tolerations }}
+            {{ toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
           tolerations:
-          {{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.securityContext }}
+            {{ toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.securityContext }}
           securityContext:
-          {{ toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.imagePullSecrets }}
+            {{ toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
-        {{- toYaml . | nindent 12 }}
-  {{- end }}
+            {{- toYaml . | nindent 12 }}
+        {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -115,7 +115,6 @@ spec:
               {{- end }}
               resources:
               {{- toYaml .Values.resources | nindent 16 }}
-            {{ toYaml .Values.resources | nindent 16 }}
             {{- if .Values.dind.enabled }}
             - name: {{ .Chart.Name }}-dind
               image: "{{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}"

--- a/charts/renovate/templates/extra-configmap.yaml
+++ b/charts/renovate/templates/extra-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.extraConfigmaps -}}
+{{- range .Values.extraConfigmaps -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "renovate.fullname" $ }}-extra-{{ .name }}
+  labels:
+    {{- include "renovate.labels" $ | nindent 4 }}
+data:
+  {{- toYaml  .data | nindent 2}}
+---
+{{- end }}
+{{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -60,7 +60,7 @@ dind:
     pullPolicy: IfNotPresent
 
 # Additional configmaps
-# A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config
+# -- A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config
 extraConfigmaps: []
 # extraConfigmaps:
 #   - name: netrc-config
@@ -75,14 +75,14 @@ extraConfigmaps: []
 #         "key"="value"
 #         "key1"="value1"
 
-# Additional volumes to the pod
+# -- Additional volumes to the pod
 extraVolumes: []
 # extraVolumes:
 #   - name: netrc-config
 #     configMap:
 #       name: renovate-extra-netrc-config
 
-# Additional volumeMounts to the container
+# -- Additional volumeMounts to the container
 extraVolumeMounts: []
 # extraVolumeMounts:
 #   - name: netrc-config

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -15,7 +15,7 @@ pod:
 
 image:
   repository: renovate/renovate
-  tag: 25.33.1
+  tag: 25.33.2
   pullPolicy: IfNotPresent
 
 imagePullSecrets: {}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -49,6 +49,36 @@ secrets: {}
 # or provide the name of an existing secret to be read instead.
 existingSecret: ''
 
+# Additional configmaps
+# A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config
+extraConfigmaps: []
+# extraConfigmaps:
+#   - name: netrc-config
+#     data:
+#       .netrc: |-
+#         machine gitlab.example.com
+#         login gitlab-ci-token
+#         password some-pass
+#   - name: yet-another-config
+#     data:
+#       ya-config.yaml: |-
+#         "key"="value"
+#         "key1"="value1"
+
+# Additional volumes to the pod
+extraVolumes: []
+# extraVolumes:
+#   - name: netrc-config
+#     configMap:
+#       name: renovate-extra-netrc-config
+
+# Additional volumeMounts to the container
+extraVolumeMounts: []
+# extraVolumeMounts:
+#   - name: netrc-config
+#     mountPath: /home/ubuntu/.netrc
+#     subPath: .netrc
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -59,8 +59,7 @@ dind:
     tag: 20.10.7-dind
     pullPolicy: IfNotPresent
 
-# Additional configmaps
-# -- A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config
+# -- Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config
 extraConfigmaps: []
 # extraConfigmaps:
 #   - name: netrc-config

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -109,7 +109,7 @@ resources:
   #  memory: 128Mi
   # requests:
   #  cpu: 100m
-#  memory: 128Mi
+  #  memory: 128Mi
 
 envFrom: []
 


### PR DESCRIPTION
Hi, this PR closes https://github.com/renovatebot/helm-charts/issues/120 

There are some new features via helm values: 
- add extra(additional) configmaps
- add extra volumes
- add extra volumeMounts

You can combine them to provide custom files(configs) to renovate's container