### PR TITLE
feat: add dind sidecar option

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the chart and the defau
 | dind.image.pullPolicy | string | `"IfNotPresent"` |  |
 | dind.image.repository | string | `"docker"` |  |
 | dind.image.tag | string | `"19.03.14-dind"` |  |
+| dind.slim.enabled | bool | `true` |  |
 | env | object | `{}` |  |
 | envFrom | list | `[]` |  |
 | existingSecret | string | `""` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -49,8 +49,8 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |
 | dind.enabled | bool | `false` |  |
 | dind.image.pullPolicy | string | `"IfNotPresent"` |  |
-| dind.image.repository | string | `"docker"` |  |
-| dind.image.tag | string | `"19.03.14-dind"` |  |
+| dind.image.repository | string | `"docker.io/library/docker"` |  |
+| dind.image.tag | string | `"20.10.7-dind"` |  |
 | dind.slim.enabled | bool | `true` |  |
 | env | object | `{}` |  |
 | envFrom | list | `[]` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -47,6 +47,10 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.labels | object | `{}` |  |
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |
+| dind.enabled | bool | `false` |  |
+| dind.image.pullPolicy | string | `"IfNotPresent"` |  |
+| dind.image.repository | string | `"docker"` |  |
+| dind.image.tag | string | `"19.03.14-dind"` |  |
 | env | object | `{}` |  |
 | envFrom | list | `[]` |  |
 | existingSecret | string | `""` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -77,3 +77,9 @@ The following table lists the configurable parameters of the chart and the defau
 | ssh_config.existingSecret | string | `""` |  |
 | ssh_config.id_rsa | string | `""` |  |
 | ssh_config.id_rsa_pub | string | `""` |  |
+
+## Docker in Docker configuration
+
+When `dind.enabled` is set to `true`, a Docker in Docker container will run as a sidecar to supply a Docker daemon to the RenovateBot container. This allows the configuration `binarySource` to be set to `docker`, which is the default configuration in the slim Docker images.
+
+The slim suffix will be added to the tag if not present. To disable this behaviour, set `dind.slim.enabled` to `false`.

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -37,3 +37,9 @@ helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' renov
 The following table lists the configurable parameters of the chart and the default values.
 
 {{ template "chart.valuesSection" . }}
+
+## Docker in Docker configuration
+
+When `dind.enabled` is set to `true`, a Docker in Docker container will run as a sidecar to supply a Docker daemon to the RenovateBot container. This allows the configuration `binarySource` to be set to `docker`, which is the default configuration in the slim Docker images.
+
+The slim suffix will be added to the tag if not present. To disable this behaviour, set `dind.slim.enabled` to `false`.

--- a/charts/renovate/ci/ci-with-dind-values.yaml
+++ b/charts/renovate/ci/ci-with-dind-values.yaml
@@ -1,0 +1,30 @@
+imagePullSecrets:
+  - name: myregistrykey
+envFrom:
+  - configMapRef:
+      name: my-config
+secrets:
+  my-secret-1: |
+    123
+  my-secret-2: |
+    456
+ssh_config:
+  enabled: true
+  config: |
+    Host *
+      ForwardAgent yes
+renovate:
+  config: |
+    {
+      "platform": "gitlab",
+      "endpoint": "https://gitlab.example.com/api/v4",
+      "token": "your-gitlab-renovate-user-token",
+      "autodiscover": "false",
+      "dryRun": true,
+      "printConfig": true,
+      "logLevel": "debug",
+      "repositories": ["username/repo", "orgname/repo"]
+    }
+
+dind:
+  enabled: true

--- a/charts/renovate/templates/_helpers.tpl
+++ b/charts/renovate/templates/_helpers.tpl
@@ -83,3 +83,12 @@ Define ssh config secret
 {{ include "renovate.fullname" . }}-ssh-secret
 {{- end -}}
 {{- end -}}
+
+{{/*
+Force slim image if dind is enabled and slim is not disabled
+*/}}
+{{- define "renovate.dindForceSlim" -}}
+{{- if and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) -}}
+{{- required "The `slim` tag should be used when dind is enabled. If you need to use another image, set `dind.slim.enabled` to false in the values." nil -}}
+{{- end -}}
+{{- end -}}

--- a/charts/renovate/templates/_helpers.tpl
+++ b/charts/renovate/templates/_helpers.tpl
@@ -87,8 +87,10 @@ Define ssh config secret
 {{/*
 Force slim image if dind is enabled and slim is not disabled
 */}}
-{{- define "renovate.dindForceSlim" -}}
+{{- define "renovate.imageTag" -}}
 {{- if and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) (not (regexMatch "^.*-slim$" .Values.image.tag)) -}}
-{{- required "The `slim` or `*-slim` tag should be used when dind is enabled. If you need to use another image, set `dind.slim.enabled` to false in the values." nil -}}
+{{- .Values.image.tag }}-slim
+{{- else -}}
+{{- .Values.image.tag }}
 {{- end -}}
 {{- end -}}

--- a/charts/renovate/templates/_helpers.tpl
+++ b/charts/renovate/templates/_helpers.tpl
@@ -88,7 +88,7 @@ Define ssh config secret
 Force slim image if dind is enabled and slim is not disabled
 */}}
 {{- define "renovate.dindForceSlim" -}}
-{{- if and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) -}}
-{{- required "The `slim` tag should be used when dind is enabled. If you need to use another image, set `dind.slim.enabled` to false in the values." nil -}}
+{{- if and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) (not (regexMatch "^.*-slim$" .Values.image.tag)) -}}
+{{- required "The `slim` or `*-slim` tag should be used when dind is enabled. If you need to use another image, set `dind.slim.enabled` to false in the values." nil -}}
 {{- end -}}
 {{- end -}}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -52,7 +52,7 @@ spec:
               args:
                 - |
                   trap "touch /tmp/main-terminated" EXIT
-                  while true; do if [[ -f "/tmp/docker-started" ]]; then break; fi; sleep 1; done
+                  while true; do if [[ -f "/tmp/dind-started" ]]; then break; fi; sleep 1; done
                   renovate
               {{- end }}
               {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.dind.enabled }}
@@ -116,8 +116,8 @@ spec:
                 - |
                   dockerd-entrypoint.sh &
                   CHILD_PID=$!
-                  while ! (ps aux | grep 'dockerd '); do sleep 1; done
-                  touch /tmp/docker-started
+                  while ! (pgrep containerd); do sleep 1; done
+                  touch /tmp/dind-started
                   (while true; do if [[ -f "/tmp/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
                   wait $CHILD_PID
                   if [[ -f "/tmp/main-terminated" ]]; then exit 0; fi

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -45,12 +45,14 @@ spec:
           containers:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              {{- include "renovate.dindForceSlim" . }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- if .Values.dind.enabled }}
               command: ["/bin/bash", "-c"]
               args:
                 - |
                   trap "touch /tmp/main-terminated" EXIT
+                  while true; do if [[ -f "/tmp/docker-started" ]]; then break; fi; sleep 1; done
                   renovate
               {{- end }}
               {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.dind.enabled }}
@@ -87,6 +89,10 @@ spec:
                 {{- if .Values.dind.enabled }}
                 - name: DOCKER_HOST
                   value: 127.0.0.1
+                - name: DOCKER_CERT_PATH
+                  value: "/tmp/certs/client"
+                - name: DOCKER_TLS_VERIFY
+                  value: "true"
                 {{- end }}
               {{- end }}
               {{- if or .Values.secrets .Values.existingSecret .Values.envFrom }}
@@ -110,12 +116,13 @@ spec:
                 - |
                   dockerd-entrypoint.sh &
                   CHILD_PID=$!
+                  touch /tmp/docker-started
                   (while true; do if [[ -f "/tmp/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
                   wait $CHILD_PID
                   if [[ -f "/tmp/main-terminated" ]]; then exit 0; fi
               env:
                 - name: DOCKER_TLS_CERTDIR
-                  value: ""
+                  value: "/tmp/certs"
               securityContext:
                 privileged: true
               volumeMounts:

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -44,8 +44,7 @@ spec:
           restartPolicy: {{ .Values.cronjob.jobRestartPolicy }}
           containers:
             - name: {{ .Chart.Name }}
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-              {{- include "renovate.dindForceSlim" . }}
+              image: "{{ .Values.image.repository }}:{{ include "renovate.imageTag" . }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- if .Values.dind.enabled }}
               command: ["/bin/bash", "-c"]

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -46,7 +46,14 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              {{- if or .Values.renovate.config .Values.ssh_config.enabled }}
+              {{- if .Values.dind.enabled }}
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  trap "touch /tmp/main-terminated" EXIT
+                  renovate
+              {{- end }}
+              {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.dind.enabled }}
               volumeMounts:
               {{- if .Values.renovate.config }}
               - name: config-volume
@@ -59,7 +66,11 @@ spec:
                 readOnly: true
               {{- end }}
               {{- end }}
-              {{- if or .Values.redis.enabled .Values.renovate.existingConfigFile .Values.env }}
+              {{- if .Values.dind.enabled }}
+              - name: {{ .Chart.Name }}-tmp-volume
+                mountPath: /tmp
+              {{- end }}
+              {{- if or .Values.redis.enabled .Values.renovate.existingConfigFile .Values.env .Values.dind.enabled }}
               env:
                 {{- if .Values.renovate.existingConfigFile }}
                 - name: RENOVATE_CONFIG_FILE
@@ -72,6 +83,10 @@ spec:
                 {{- range $k, $v := .Values.env }}
                 - name: {{ $k | quote }}
                   value: {{ $v | quote }}
+                {{- end }}
+                {{- if .Values.dind.enabled }}
+                - name: DOCKER_HOST
+                  value: 127.0.0.1
                 {{- end }}
               {{- end }}
               {{- if or .Values.secrets .Values.existingSecret .Values.envFrom }}
@@ -86,6 +101,27 @@ spec:
               {{- end }}
               resources:
                 {{ toYaml .Values.resources | nindent 16 }}
+            {{- if .Values.dind.enabled }}
+            - name: {{ .Chart.Name }}-dind
+              image: "{{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}"
+              imagePullPolicy: {{ .Values.dind.image.pullPolicy }}
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  dockerd-entrypoint.sh &
+                  CHILD_PID=$!
+                  (while true; do if [[ -f "/tmp/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
+                  wait $CHILD_PID
+                  if [[ -f "/tmp/main-terminated" ]]; then exit 0; fi
+              env:
+                - name: DOCKER_TLS_CERTDIR
+                  value: ""
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: {{ .Chart.Name }}-tmp-volume
+                  mountPath: /tmp
+            {{- end }}
           volumes:
             {{- if .Values.renovate.config }}
             - name: config-volume
@@ -96,6 +132,10 @@ spec:
             - name: ssh-config-volume
               secret:
                 secretName: {{ include "renovate.sshSecretName" .}}
+            {{- end }}
+            {{- if .Values.dind.enabled }}
+            - name: {{ .Chart.Name }}-tmp-volume
+              emptyDir: {}
             {{- end }}
         {{- with .Values.nodeSelector }}
           nodeSelector:

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -88,7 +88,7 @@ spec:
                 {{- end }}
                 {{- if .Values.dind.enabled }}
                 - name: DOCKER_HOST
-                  value: 127.0.0.1
+                  value: 127.0.0.1:2376
                 - name: DOCKER_CERT_PATH
                   value: "/tmp/certs/client"
                 - name: DOCKER_TLS_VERIFY
@@ -116,6 +116,7 @@ spec:
                 - |
                   dockerd-entrypoint.sh &
                   CHILD_PID=$!
+                  while ! (ps aux | grep 'dockerd '); do sleep 1; done
                   touch /tmp/docker-started
                   (while true; do if [[ -f "/tmp/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
                   wait $CHILD_PID

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -49,6 +49,14 @@ secrets: {}
 # or provide the name of an existing secret to be read instead.
 existingSecret: ''
 
+dind:
+  # Enable dind sidecar?
+  enabled: false
+  image:
+    repository: docker
+    tag: 19.03.14-dind
+    pullPolicy: IfNotPresent
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -52,6 +52,8 @@ existingSecret: ''
 dind:
   # Enable dind sidecar?
   enabled: false
+  slim:
+    enabled: true
   image:
     repository: docker
     tag: 19.03.14-dind

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -55,8 +55,8 @@ dind:
   slim:
     enabled: true
   image:
-    repository: docker
-    tag: 19.03.14-dind
+    repository: docker.io/library/docker
+    tag: 20.10.7-dind
     pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
Hi, this PR closes #91

There are some new features via helm values:

    enable dind container
    change the used dind docker image

This will allow the user to enable the `binarySource=docker` option.