### PR TITLE
ci: skip install job on local pr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,7 @@ jobs:
   install-chart:
     name: install-chart
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.repository_owner != github.event.pull_request.head.repo.owner.login }}
     needs:
       - lint-chart
       - lint-docs


### PR DESCRIPTION
Skip install chart job for local pr ( pull request source is local repo), so we don't run that expensive  job twice for maintainer / renovate pr's