### PR TITLE
ci: use up-to-date k8s schema

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 KUBEVAL_VERSION=v0.16.1
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/main -- charts | cut -d '/' -f 2 | uniq)"
-SCHEMA_LOCATION="https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/"
+SCHEMA_LOCATION="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
 
 # install kubeval
 curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-linux-amd64.tar.gz


### PR DESCRIPTION
The original repository hasn't been updated in over a year. This new fork has the most stars, and is kept up-to-date with more recent k8s versions.