### PR TITLE
docs(readme): use one sentence per line, add kubernetes version support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,24 @@
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/renovatebot/helm-charts?style=for-the-badge)](https://github.com/renovatebot/helm-charts/releases/latest)
 [![License](https://img.shields.io/github/license/renovatebot/helm-charts?style=for-the-badge)](https://opensource.org/licenses/AGPL-3.0)
 
-Automated dependency updates. Multi-platform and multi-language.
+Automated dependency updates.
+Multi-platform and multi-language.
 
-This repository hosts Renovate's [Helm](https://helm.sh) charts. Chart documentation is automatically generated using [helm-docs](https://github.com/norwoodj/helm-docs)
+This repository hosts Renovate's [Helm](https://helm.sh) charts.
+Chart documentation is automatically generated using [helm-docs](https://github.com/norwoodj/helm-docs).
+
+## Kubernetes version support
+
+We test the following versions of Kubernetes:
+
+| Cloud | Lowest | Highest |
+| ----- | :----: | :-----: |
+| AWS   | `1.16` | `1.20`  |
+| Azure | `1.18` | `1.20`  |
+| GCP   | `1.18` | `1.20`  |
+
+We will test on the latest 4 versions of Kubernetes.
+The general concept is that we track the versions of Kubernetes that are supported by the major cloud providers.
 
 ## Add Helm repository
 
@@ -28,11 +43,12 @@ Using config from a string:
 helm install --generate-name --set renovate.config='\{\"token\":\"...\"\}' renovate/renovate
 ```
 
-**NOTE**: `renovate.config` must be a valid Renovate [self-hosted configuration](https://docs.renovatebot.com/self-hosted-configuration/)
+**Note**: `renovate.config` must be a valid Renovate [self-hosted configuration](https://docs.renovatebot.com/self-hosted-configuration/).
 
 ## Contributing
 
-When using this repo locally or contributing to this repo, you will need to build the dependencies used for each helm chart. You can run the following commands to do so:
+When using this repo locally or contributing to this repo, you will need to build the dependencies used for each helm chart.
+You can run the following commands to do so:
 
 ```bash
 helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/README.md
+++ b/README.md
@@ -11,15 +11,7 @@ Chart documentation is automatically generated using [helm-docs](https://github.
 
 ## Kubernetes version support
 
-We test the following versions of Kubernetes:
-
-| Cloud | Lowest | Highest |
-| ----- | :----: | :-----: |
-| AWS   | `1.16` | `1.20`  |
-| Azure | `1.18` | `1.20`  |
-| GCP   | `1.18` | `1.20`  |
-
-We will test on the latest 4 versions of Kubernetes.
+We test the four latest versions of Kubernetes.
 The general concept is that we track the versions of Kubernetes that are supported by the major cloud providers.
 
 ## Add Helm repository


### PR DESCRIPTION
## Changes:

- Use one sentence per line
- End sentences with a full stop
- Reduce capitalization of **Note:** message
- Add Kubernetes version support info
- Run the latest version of Prettier on the file

## Context:

I think we should at least put the version support info in the README of this repository. 😉 