### PR TITLE
fix: use `batch/v1` api version if available

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
-set -euxo pipefail
 
 mkdir ./.bin
 export PATH="./.bin:$PATH"
+
+set -euxo pipefail
 
 # renovate: datasource=github-releases depName=helm-docs lookupName=norwoodj/helm-docs
 HELM_DOCS_VERSION=1.5.0
 
 # install helm-docs
 curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz
-tar -xf /tmp/helm-docs.tar.gz .bin/helm-docs
+tar -C .bin/ -xf /tmp/helm-docs.tar.gz helm-docs
 
 # validate docs
 helm-docs

--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -euxo pipefail
 
+mkdir ./.bin
+export PATH="./.bin:$PATH"
+
 # renovate: datasource=github-releases depName=helm-docs lookupName=norwoodj/helm-docs
 HELM_DOCS_VERSION=1.5.0
 
 # install helm-docs
 curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz
-tar -xf /tmp/helm-docs.tar.gz helm-docs
+tar -xf /tmp/helm-docs.tar.gz .bin/helm-docs
 
 # validate docs
-./helm-docs
+helm-docs
 git diff --exit-code

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,22 +1,37 @@
 #!/bin/bash
 set -euxo pipefail
 
+mkdir ./.bin
+export PATH="./.bin:$PATH"
 
 # renovate: datasource=github-releases depName=kubeval lookupName=instrumenta/kubeval
 KUBEVAL_VERSION=v0.16.1
+
+# renovate: datasource=github-releases depName=semver2 lookupName=Ariel-Rodriguez/sh-semversion-2
+SEMVER_VERSION=1.0.3
 
 CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/main -- charts | cut -d '/' -f 2 | uniq)"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
 
 # install kubeval
 curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-linux-amd64.tar.gz
-tar -xf /tmp/kubeval.tar.gz kubeval
+tar -xf /tmp/kubeval.tar.gz .bin/kubeval
+
+# install semver compare
+curl -sSfLo .bin/semver2 https://raw.githubusercontent.com/Ariel-Rodriguez/sh-semversion-2/${SEMVER_VERSION}/semver2.sh
+chmod +x .bin/semver2
 
 # add helm repos
 helm repo add bitnami https://charts.bitnami.com/bitnami
 
-# TODO: conditionally add apis
-apis='--api-versions batch/v1beta1/CronJob'
+# Compute required kubernetes api versions
+apis=''
+
+if [[ "$(semver2 ${KUBERNETES_VERSION#v} 1.21.0)" -ge 0 ]]; then
+  apis="${apis} --api-versions batch/v1/CronJob"
+else
+  apis="${apis} --api-versions batch/v1beta1/CronJob"
+fi
 
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
@@ -24,7 +39,7 @@ for CHART_DIR in ${CHART_DIRS}; do
   helm template \
     $apis \
     --values charts/"${CHART_DIR}"/ci/ci-values.yaml \
-    charts/"${CHART_DIR}" | ./kubeval \
+    charts/"${CHART_DIR}" | kubeval \
       --strict \
       --ignore-missing-schemas \
       --kubernetes-version "${KUBERNETES_VERSION#v}" \

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -15,8 +15,13 @@ tar -xf /tmp/kubeval.tar.gz kubeval
 # add helm repos
 helm repo add bitnami https://charts.bitnami.com/bitnami
 
+# TODO: conditionally
+apis=-a batch/v1beta1/CronJob
+
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
   (cd charts/${CHART_DIR}; helm dependency build)
-  helm template --values charts/"${CHART_DIR}"/ci/ci-values.yaml charts/"${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
+  helm template --values charts/"${CHART_DIR}"/ci/ci-values.yaml charts/"${CHART_DIR}" \
+    $apis \
+    | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
 done

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -15,13 +15,18 @@ tar -xf /tmp/kubeval.tar.gz kubeval
 # add helm repos
 helm repo add bitnami https://charts.bitnami.com/bitnami
 
-# TODO: conditionally
-apis=-a batch/v1beta1/CronJob
+# TODO: conditionally add apis
+apis='--api-versions batch/v1beta1/CronJob'
 
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
   (cd charts/${CHART_DIR}; helm dependency build)
-  helm template --values charts/"${CHART_DIR}"/ci/ci-values.yaml charts/"${CHART_DIR}" \
+  helm template \
     $apis \
-    | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
+    --values charts/"${CHART_DIR}"/ci/ci-values.yaml \
+    charts/"${CHART_DIR}" | ./kubeval \
+      --strict \
+      --ignore-missing-schemas \
+      --kubernetes-version "${KUBERNETES_VERSION#v}" \
+      --schema-location "${SCHEMA_LOCATION}"
 done

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-set -euxo pipefail
 
 mkdir ./.bin
 export PATH="./.bin:$PATH"
+
+set -euxo pipefail
 
 # renovate: datasource=github-releases depName=kubeval lookupName=instrumenta/kubeval
 KUBEVAL_VERSION=v0.16.1
@@ -15,7 +16,7 @@ SCHEMA_LOCATION="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/
 
 # install kubeval
 curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-linux-amd64.tar.gz
-tar -xf /tmp/kubeval.tar.gz .bin/kubeval
+tar -C .bin/ -xf /tmp/kubeval.tar.gz kubeval
 
 # install semver compare
 curl -sSfLo .bin/semver2 https://raw.githubusercontent.com/Ariel-Rodriguez/sh-semversion-2/${SEMVER_VERSION}/semver2.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 charts/*/charts
+.bin/

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -1,4 +1,10 @@
+  {{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+apiVersion: batch/v1
+  {{- else if .Capabilities.APIVersions.Has "batch/v1beta1/CronJob" }}
 apiVersion: batch/v1beta1
+  {{- else }}
+    {{- fail "\n\n ERROR: You must have atleast batch/v1beta1 to use CronJob" }}
+  {{- end }}
 kind: CronJob
 metadata:
   name: {{ include "renovate.fullname" . }}


### PR DESCRIPTION
closes #143 

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125