### PR TITLE
fix: `RENOVATE_CONFIG_FILE` not being rendered

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -85,7 +85,7 @@ spec:
               - name: {{ .Chart.Name }}-tmp-volume
                 mountPath: /tmp
               {{- end }}
-              {{- if or .Values.redis.enabled .Values.renovate.existingConfigFile .Values.env .Values.dind.enabled }}
+              {{- if or .Values.redis.enabled .Values.renovate.config .Values.renovate.existingConfigFile .Values.env .Values.dind.enabled }}
               env:
                 {{- if .Values.renovate.existingConfigFile }}
                 - name: RENOVATE_CONFIG_FILE


### PR DESCRIPTION
- Fixes #173
- Fixes https://github.com/renovatebot/renovate/issues/13054
- regression of #170 