### PR TITLE
feat: remove if clauses wrapping env and envFrom

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "renovate.labels" . | nindent 4 }}
 data:
   config.json: |-
-    {{ required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" .Values.renovate.config | nindent 4 }}
+    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" .Values.renovate.config | nindent 4 }}
 {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -88,7 +88,6 @@ spec:
               - name: {{ .Chart.Name }}-tmp-volume
                 mountPath: /tmp
               {{- end }}
-              {{- if or .Values.redis.enabled .Values.renovate.config .Values.renovate.existingConfigFile .Values.env .Values.dind.enabled }}
               env:
                 {{- if .Values.renovate.existingConfigFile }}
                 - name: RENOVATE_CONFIG_FILE
@@ -113,8 +112,6 @@ spec:
                 - name: DOCKER_TLS_VERIFY
                   value: "true"
                 {{- end }}
-              {{- end }}
-              {{- if or .Values.secrets .Values.existingSecret .Values.envFrom }}
               envFrom:
                 {{- if or .Values.secrets .Values.existingSecret }}
                 - secretRef:
@@ -123,7 +120,6 @@ spec:
                 {{- with .Values.envFrom }}
                   {{- toYaml . | nindent 16 }}
                 {{- end }}
-              {{- end }}
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
             {{- if .Values.dind.enabled }}


### PR DESCRIPTION
High complexity `if or` make easy to forget to add new conditions to the list, which can easily hide typos. This PR simply removes the ifs, causing `env` and `envFrom` to be rendered inconditionally.

As a downside, in some cases, this can result in empty keys, like `envFrom` below:
```yaml
containers:
  - name: renovate
    image: "renovate/renovate:30.2.1"
    imagePullPolicy: IfNotPresent
    envFrom:
    resources:
      {}
```

This, however, is legal yaml and applies fine on my clusters. Moreover, the chart is already doing this, by including empty strings without `| quote`:
```
    spec:
      backoffLimit:
      template:
        metadata:
```

If for some reason this is not wanted, an alternative approach could be to extract the env generation to a template:
```gotpl
{{- define "renovate.cronjob.env" -}}
{{- if .Values.renovate.existingConfigFile }}
- name: RENOVATE_CONFIG_FILE
  value: {{ .Values.renovate.existingConfigFile }}
  {{- else if .Values.renovate.config }}
- name: RENOVATE_CONFIG_FILE
  value: /usr/src/app/config.json
  {{- end }}
  {{- if .Values.redis.enabled }}
- name: RENOVATE_REDIS_URL
  value: redis://{{ include "renovate.redisHost" . }}
  {{- end }}
  {{- range $k, $v := .Values.env }}
- name: {{ $k | quote }}
  value: {{ $v | quote }}
  {{- end }}
  {{- if .Values.dind.enabled }}
- name: DOCKER_HOST
  value: 127.0.0.1:2376
- name: DOCKER_CERT_PATH
  value: "/tmp/certs/client"
- name: DOCKER_TLS_VERIFY
  value: "true"
{{- end }}
{{- end -}}

// ...

{{- if include "renovate.cronjob.env" . }}
env:
  {{- include "renovate.cronjob.env" . | trim | nindent 16 }}
{{- end }}
```

But I'm not sure if this the increased complexity is wanted here: We would get the logic in a different place.

What are your thoughts?