### PR TITLE
chore: fix helm-docs version extraction

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,11 @@
       "matchPackageNames": ["kindest/node"],
       "matchUpdateTypes": ["major", "minor"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Trim leading v from version for helm-docs",
+      "matchPackageNames": ["helm-docs"],
+      "extractVersion": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
     }
   ]
 }


### PR DESCRIPTION
Drop leading `v` on version extraction

ref:
- #179
- #183 
- 265c30069ba6f6663197f163c434f450e0fe4947