### PR TITLE
chore: update k8s test matrix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ARG DOCKER_VERSION=v20.10.16
 RUN install-tool docker
 
 # renovate: datasource=github-tags depName=kubectl lookupName=kubernetes/kubectl
-ARG KUBECTL_VERSION=1.20.1
+ARG KUBECTL_VERSION=1.24.1
 RUN install-tool kubectl
 
 # renovate: datasource=github-releases depName=kind lookupName=kubernetes-sigs/kind

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - 'renovate/**'
   pull_request:
-  
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
@@ -23,7 +23,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.7.2 # renovate: datasource=github-releases depName=helm lookupName=helm/helm
+          version: v3.9.0 # renovate: datasource=github-releases depName=helm lookupName=helm/helm
 
       - uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # tag=v3.1.2
         with:
@@ -32,7 +32,7 @@ jobs:
       - name: Install chart-testing
         uses: helm/chart-testing-action@dae259e86a35ff09145c0805e2d7dd3f7207064a # tag=v2.2.1
         with:
-          version: v3.4.0 # renovate: datasource=github-releases depName=chart-testing lookupName=helm/chart-testing
+          version: v3.6.0 # renovate: datasource=github-releases depName=chart-testing lookupName=helm/chart-testing
 
       - name: Run lint
         run: ct lint --config .github/ct.yaml
@@ -55,12 +55,11 @@ jobs:
       matrix:
         k8s:
           # from https://github.com/yannh/kubernetes-json-schema
-          - v1.18.20
-          - v1.19.16
-          - v1.20.13
-          - v1.21.7
-          - v1.22.4
-          - v1.23.0
+          - v1.20.15
+          - v1.21.13
+          - v1.22.10
+          - v1.23.7
+          - v1.24.1
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
@@ -84,12 +83,11 @@ jobs:
       matrix:
         k8s:
           # from https://hub.docker.com/r/kindest/node/tags
+          - v1.20.15 # renovate: kindest
+          - v1.21.12 # renovate: kindest
+          - v1.22.9 # renovate: kindest
+          - v1.23.6 # renovate: kindest
           - v1.24.1 # renovate: kindest
-          - v1.19.11 # renovate: kindest
-          - v1.24.1 # renovate: kindest
-          - v1.21.2 # renovate: kindest
-          - v1.24.1 # renovate: kindest
-          - v1.23.0 # renovate: kindest
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
@@ -100,12 +98,12 @@ jobs:
         uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 # renovate: tag=v1.2.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
-          version: v0.11.1 # renovate: datasource=github-releases depName=kind lookupName=kubernetes-sigs/kind
+          version: v0.14.0 # renovate: datasource=github-releases depName=kind lookupName=kubernetes-sigs/kind
 
       - name: Install chart-testing
         uses: helm/chart-testing-action@dae259e86a35ff09145c0805e2d7dd3f7207064a # tag=v2.2.1
         with:
-          version: v3.4.0 # renovate: datasource=github-releases depName=chart-testing lookupName=helm/chart-testing
+          version: v3.6.0 # renovate: datasource=github-releases depName=chart-testing lookupName=helm/chart-testing
 
       - name: Run chart install
         run: ct install --config .github/ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'charts/**'
-
   workflow_dispatch:
 
 jobs:
@@ -26,7 +25,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.7.2 # renovate: datasource=github-releases depName=helm lookupName=helm/helm
+          version: v3.9.0 # renovate: datasource=github-releases depName=helm lookupName=helm/helm
 
       - name: Add external Helm repos
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -41,6 +40,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@a3454e46a6f5ac4811069a381e646961dda2e1bf # tag=v1.4.0
         with:
-          version: v1.3.0 # renovate: datasource=github-releases depName=chart-releaser lookupName=helm/chart-releaser
+          version: v1.4.0 # renovate: datasource=github-releases depName=chart-releaser lookupName=helm/chart-releaser
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,7 +37,7 @@
     {
       "label": "kubeval",
       "type": "shell",
-      "command": "helm template --values ${workspaceFolder}/charts/renovate/ci/ci-values.yaml ${workspaceFolder}/charts/renovate | kubeval --strict --kubernetes-version 1.18.1 --schema-location https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/",
+      "command": "helm template --values ${workspaceFolder}/charts/renovate/ci/ci-values.yaml ${workspaceFolder}/charts/renovate | kubeval --strict --kubernetes-version 1.24.1 --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",


### PR DESCRIPTION
Kubernetes 1.20.x is the oldest version supported across the major cloud providers.

Also updates some actions used in ci that were not correctly identified by Renovate (Needs further investigation).

- Closes #209
- Closes #178