### PR TITLE
docs: document securityContext values option

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
 | resources | object | `{}` |  |
 | secrets | object | `{}` |  |
+| securityContext | object | `{}` | Pod-level security-context |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -158,3 +158,6 @@ hostAliases: []
 #   - ip: "your-ip"
 #     hostnames:
 #       - "your-hostname"
+
+# Pod-level security-context
+securityContext: {}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -159,5 +159,5 @@ hostAliases: []
 #     hostnames:
 #       - "your-hostname"
 
-# Pod-level security-context
+# -- Pod-level security-context
 securityContext: {}


### PR DESCRIPTION
The template already supports adding pod-level securityContext options but it's currently not documented in the values file