### PR TITLE
feat: add initContainers support

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"32.125.0"` |  |
 | imagePullSecrets | object | `{}` |  |
+| initContainers | list | `[]` | Additional initContainers that can be executed before renovate |
 | pod.annotations | object | `{}` |  |
 | pod.labels | object | `{}` |  |
 | redis.architecture | string | `"standalone"` | Disable replication by default |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.annotations | object | `{}` |  |
 | cronjob.concurrencyPolicy | string | `""` |  |
 | cronjob.failedJobsHistoryLimit | string | `""` |  |
+| cronjob.initContainers | list | `[]` | Additional initContainers that can be executed before renovate |
 | cronjob.jobBackoffLimit | string | `""` |  |
 | cronjob.jobRestartPolicy | string | `"Never"` |  |
 | cronjob.labels | object | `{}` |  |
@@ -67,7 +68,6 @@ The following table lists the configurable parameters of the chart and the defau
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"32.125.0"` |  |
 | imagePullSecrets | object | `{}` |  |
-| initContainers | list | `[]` | Additional initContainers that can be executed before renovate |
 | pod.annotations | object | `{}` |  |
 | pod.labels | object | `{}` |  |
 | redis.architecture | string | `"standalone"` | Disable replication by default |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -60,6 +60,10 @@ spec:
           hostAliases:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+          {{- if .Values.initContainers }}
+          initContainers:
+            {{- toYaml .Values.initContainers | nindent 12 }}
+          {{- end }}
           containers:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ include "renovate.imageTag" . }}"

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -60,9 +60,9 @@ spec:
           hostAliases:
             {{- toYaml . | nindent 12 }}
         {{- end }}
-          {{- if .Values.initContainers }}
+          {{- if .Values.cronjob.initContainers }}
           initContainers:
-            {{- toYaml .Values.initContainers | nindent 12 }}
+            {{- toYaml .Values.cronjob.initContainers | nindent 12 }}
           {{- end }}
           containers:
             - name: {{ .Chart.Name }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -11,6 +11,11 @@ cronjob:
   jobRestartPolicy: Never
   jobBackoffLimit: ''
   startingDeadlineSeconds: ''
+  # -- Add init containers to be run before renovate
+  initContainers: []
+  # initContainers:
+  # - name: INIT_CONTAINER_NAME
+  #   image: INIT_CONTAINER_IMAGE
 
 pod:
   annotations: {}
@@ -159,8 +164,3 @@ hostAliases: []
 #     hostnames:
 #       - "your-hostname"
 
-# -- Add init containers to be run before renovate
-initContainers: []
-# initContainers:
-# - name: INIT_CONTAINER_NAME
-#   image: INIT_CONTAINER_IMAGE

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -158,3 +158,9 @@ hostAliases: []
 #   - ip: "your-ip"
 #     hostnames:
 #       - "your-hostname"
+
+# -- Add init containers to be run before renovate
+initContainers: []
+# initContainer:
+# - name: INIT_CONTAINER_NAME
+#   image: INIT_CONTAINER_IMAGE

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -163,4 +163,3 @@ hostAliases: []
 #   - ip: "your-ip"
 #     hostnames:
 #       - "your-hostname"
-

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -161,6 +161,6 @@ hostAliases: []
 
 # -- Add init containers to be run before renovate
 initContainers: []
-# initContainer:
+# initContainers:
 # - name: INIT_CONTAINER_NAME
 #   image: INIT_CONTAINER_IMAGE

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -11,7 +11,7 @@ cronjob:
   jobRestartPolicy: Never
   jobBackoffLimit: ''
   startingDeadlineSeconds: ''
-  # -- Add init containers to be run before renovate
+  # -- Additional initContainers that can be executed before renovate
   initContainers: []
   # initContainers:
   # - name: INIT_CONTAINER_NAME


### PR DESCRIPTION
This pull requests attempt to add support for initContainers. A brief example on how one would look like. This could be useful, for example, for determining a github app token just before renovate executes.
