### PR TITLE
Add Security Context and remove resource block if not set #202

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the chart and the defau
 | dind.image.pullPolicy | string | `"IfNotPresent"` |  |
 | dind.image.repository | string | `"docker"` |  |
 | dind.image.tag | string | `"20.10.17-dind"` |  |
+| dind.securityContext | object | `{"privileged":true}` | DinD Container-level security-context. Privilged is needed for DinD, it will not work without! |
 | dind.slim.enabled | bool | `true` | Do not add `-slim` suffix to image tag when using dind |
 | env | object | `{}` |  |
 | envFrom | list | `[]` |  |
@@ -76,6 +77,7 @@ The following table lists the configurable parameters of the chart and the defau
 | redis.kubeVersion | string | `""` | Override Kubernetes version for redis chart |
 | renovate.config | string | `""` | Inline global renovate config.json |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
+| renovate.securityContext | object | `{}` | Renovate Container-level security-context |
 | resources | object | `{}` |  |
 | secrets | object | `{}` |  |
 | securityContext | object | `{}` | Pod-level security-context |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -131,8 +131,14 @@ spec:
                 {{- with .Values.envFrom }}
                   {{- toYaml . | nindent 16 }}
                 {{- end }}
+            {{- with .Values.renovate.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.resources }}
               resources:
-                {{- toYaml .Values.resources | nindent 16 }}
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
             {{- if .Values.dind.enabled }}
             - name: {{ .Chart.Name }}-dind
               image: "{{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}"
@@ -150,8 +156,10 @@ spec:
               env:
                 - name: DOCKER_TLS_CERTDIR
                   value: "/tmp/certs"
+            {{- with .Values.dind.securityContext }}
               securityContext:
-                privileged: true
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
               volumeMounts:
                 - name: {{ .Chart.Name }}-tmp-volume
                   mountPath: /tmp

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -45,6 +45,9 @@ renovate:
   #     "repositories": ["username/repo", "orgname/repo"]
   #   }
 
+  # -- Renovate Container-level security-context
+  securityContext: {}
+
 ssh_config:
   enabled: false
   # Provide .ssh config file contents
@@ -68,6 +71,10 @@ dind:
     repository: docker
     tag: 20.10.17-dind
     pullPolicy: IfNotPresent
+
+  # -- DinD Container-level security-context. Privilged is needed for DinD, it will not work without!
+  securityContext:
+    privileged: true
 
 # -- Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config
 extraConfigmaps: []
@@ -107,8 +114,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ''
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
Hi,

I created this PR to integrate the possibility to set the SecurityContext on Container Level. Fix for #202
This is needed, for example, to set capabilities.  

I also changed the resource statement a bit to have the CronJob yaml clean when resources are not set.

- closes #202

Signed-off-by: dschunack <dschunack@web.de>