### PR TITLE
add preCommand value to cronjob template

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.jobBackoffLimit | string | `""` |  |
 | cronjob.jobRestartPolicy | string | `"Never"` |  |
 | cronjob.labels | object | `{}` |  |
-| cronjob.overrideCommand | string | `""` | prepend shell commands before renovate runs |
+| cronjob.preCommand | string | `""` | prepend shell commands before renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.startingDeadlineSeconds | string | `""` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.jobBackoffLimit | string | `""` |  |
 | cronjob.jobRestartPolicy | string | `"Never"` |  |
 | cronjob.labels | object | `{}` |  |
+| cronjob.preCommand | string | `""` | prepend shell commands before renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.startingDeadlineSeconds | string | `""` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -48,7 +48,6 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.jobBackoffLimit | string | `""` |  |
 | cronjob.jobRestartPolicy | string | `"Never"` |  |
 | cronjob.labels | object | `{}` |  |
-| cronjob.preCommand | string | `""` | prepend shell commands before renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.startingDeadlineSeconds | string | `""` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.jobBackoffLimit | string | `""` |  |
 | cronjob.jobRestartPolicy | string | `"Never"` |  |
 | cronjob.labels | object | `{}` |  |
-| cronjob.preCommand | string | `""` | prepend shell commands before renovate runs |
+| cronjob.preCommand | string | `""` | Prepend shell commands before renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.startingDeadlineSeconds | string | `""` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.jobBackoffLimit | string | `""` |  |
 | cronjob.jobRestartPolicy | string | `"Never"` |  |
 | cronjob.labels | object | `{}` |  |
+| cronjob.overrideCommand | string | `""` | prepend shell commands before renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` |  |
 | cronjob.startingDeadlineSeconds | string | `""` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -74,8 +74,8 @@ spec:
               {{- if or .Values.dind.enabled .Values.cronjob.overrideCommand}}
               command: ["/bin/bash", "-c"]
               args:
-                {{- if .Values.dind.enabled }} 
                 - | 
+                {{- if .Values.dind.enabled }} 
                   trap "touch /tmp/main-terminated" EXIT
                   while true; do if [[ -f "/tmp/dind-started" ]]; then break; fi; sleep 1; done
                 {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -71,13 +71,18 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ include "renovate.imageTag" . }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              {{- if .Values.dind.enabled }}
+              {{- if or .Values.dind.enabled .Values.cronjob.overrideCommand}}
               command: ["/bin/bash", "-c"]
               args:
-                - |
+                {{- if .Values.dind.enabled }} 
+                - | 
                   trap "touch /tmp/main-terminated" EXIT
                   while true; do if [[ -f "/tmp/dind-started" ]]; then break; fi; sleep 1; done
-                  renovate
+                {{- end }}
+                {{- if .Values.cronjob.overrideCommand }} 
+                  {{- .Values.cronjob.overrideCommand | nindent 18 }}
+                {{- end -}}
+                renovate
               {{- end }}
               {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.dind.enabled .Values.extraVolumes }}
               volumeMounts:

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -71,7 +71,7 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ include "renovate.imageTag" . }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              {{- if or .Values.dind.enabled .Values.cronjob.overrideCommand}}
+              {{- if or .Values.dind.enabled .Values.cronjob.preCommand}}
               command: ["/bin/bash", "-c"]
               args:
                 - | 
@@ -79,8 +79,8 @@ spec:
                   trap "touch /tmp/main-terminated" EXIT
                   while true; do if [[ -f "/tmp/dind-started" ]]; then break; fi; sleep 1; done
                 {{- end }}
-                {{- if .Values.cronjob.overrideCommand }} 
-                  {{- .Values.cronjob.overrideCommand | nindent 18 }}
+                {{- if .Values.cronjob.preCommand }} 
+                  {{- .Values.cronjob.preCommand | nindent 18 }}
                 {{- end -}}
                 renovate
               {{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -23,7 +23,7 @@ cronjob:
   # - name: INIT_CONTAINER_NAME
   #   image: INIT_CONTAINER_IMAGE
 
-  # -- prepend shell commands before renovate runs
+  # -- Prepend shell commands before renovate runs
   preCommand: ''
   # preCommand: |
   #   echo hello

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -23,7 +23,7 @@ cronjob:
   # - name: INIT_CONTAINER_NAME
   #   image: INIT_CONTAINER_IMAGE
 
-  # -- add pre-commands before renovate runs
+  # -- prepend shell commands before renovate runs
   preCommand: ''
   # preCommand: |
   #   echo hello

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -23,6 +23,12 @@ cronjob:
   # - name: INIT_CONTAINER_NAME
   #   image: INIT_CONTAINER_IMAGE
 
+  # -- add pre-commands before renovate runs
+  overrideCommand: ''
+  # overrideCommand: |
+  #   echo hello
+  #   echo world
+
 pod:
   annotations: {}
   labels: {}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -24,8 +24,8 @@ cronjob:
   #   image: INIT_CONTAINER_IMAGE
 
   # -- add pre-commands before renovate runs
-  overrideCommand: ''
-  # overrideCommand: |
+  preCommand: ''
+  # preCommand: |
   #   echo hello
   #   echo world
 


### PR DESCRIPTION
I've created a fix for Github app token renewal as mentioned here #248. 

My use case is the following.

- Create an init container to handle github app token renewal and write the token into a file like so 
  - `export RENOVATE_TOKEN=xxxxxx`
- The file containing the RENOVATE_TOKEN export is written to a common volume of type emptyDir that  is mounted on the same path on both the init container and the main container i.e. `/common`

The following configuration in the values file will inject an argument(s) before renovate runs within the main container. 

```
  preCommand: | 
      source /common/renovate.env
```

In this usecase exporting the RENOVATE_TOKEN to provide renovate the ability to authenticate with the appropriate Github repositories where the Custom Github application is installed.

<img width="444" alt="image" src="https://user-images.githubusercontent.com/17338080/196825138-1e85aae3-fdaa-4a3e-b821-2e45666cb46b.png">

Note that you can run any sequence of shell commands before the image runs