### PR TITLE
fix: activeDeadlineSeconds to optional

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -41,7 +41,9 @@ spec:
       labels:
         {{- include "renovate.selectorLabels" . | nindent 8 }}
     spec:
-      activeDeadlineSeconds: {{ default 600 .Values.cronjob.activeDeadlineSeconds }}
+      {{- if .Values.cronjob.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.cronjob.activeDeadlineSeconds }}
+      {{- end }}
       {{- if .Values.cronjob.jobBackoffLimit }}
       backoffLimit: {{ .Values.cronjob.jobBackoffLimit }}
       {{- end }}


### PR DESCRIPTION
## why

The `activeDeadlineSeconds` value can be set from this pull-request https://github.com/renovatebot/helm-charts/pull/249, but `600` is applied by [default](https://github.com/renovatebot/helm-charts/blob/9f47b812620a77b27a90cbe0caf3f33503e75fb4/charts/renovate/templates/cronjob.yaml#L44). This is a breaking change and, it should be applied when chart users need it. And, if configuring the default value, I think `600` is too short. Anyway, it should be optional.