### PR TITLE
feat: added tpl to enable templated config values

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | redis.enabled | bool | `false` | Enable the Redis subchart? |
 | redis.kubeVersion | string | `""` | Override Kubernetes version for redis chart |
 | renovate.config | string | `""` | Inline global renovate config.json |
-| renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration Allows you to reference values using "{{ .Values.someValue }}" in your config NOTE: using this means that you have to escape your config entries in the config key above containing {{ in the value by wrapping it like this: "key": "{{ "{{depName}}" }}" |
+| renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See README for how to use this value |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
 | renovate.securityContext | object | `{}` | Renovate Container-level security-context |
 | resources | object | `{}` |  |
@@ -103,3 +103,11 @@ The slim suffix will be added to the tag if not present. To disable this behavio
 ## Redis
 
 Please checkout [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
+
+## renovate.configEnableHelmTpl
+Allows you to reference values using `"{{ .Values.someValue }}"` in your config
+
+**NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to
+escape your config entries containing `{{` (i.e. `"key": "{{depName}}"`) in the
+value by wrapping it like: `"key": "{{ "{{depName}}" }}"`.
+

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -104,7 +104,9 @@ The slim suffix will be added to the tag if not present. To disable this behavio
 
 Please checkout [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
 
-## renovate.configEnableHelmTpl
+## Renovate config templating
+
+Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
 Allows you to reference values using `"{{ .Values.someValue }}"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | redis.enabled | bool | `false` | Enable the Redis subchart? |
 | redis.kubeVersion | string | `""` | Override Kubernetes version for redis chart |
 | renovate.config | string | `""` | Inline global renovate config.json |
-| configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See values.yaml for more information |
+| renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration Allows you to reference values using "{{ .Values.someValue }}" in your config NOTE: using this means that you have to escape your config entries in the config key above containing {{ in the value by wrapping it like this: "key": "{{ "{{depName}}" }}" |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
 | renovate.securityContext | object | `{}` | Renovate Container-level security-context |
 | resources | object | `{}` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | redis.enabled | bool | `false` | Enable the Redis subchart? |
 | redis.kubeVersion | string | `""` | Override Kubernetes version for redis chart |
 | renovate.config | string | `""` | Inline global renovate config.json |
+| configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See values.yaml for more information |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
 | renovate.securityContext | object | `{}` | Renovate Container-level security-context |
 | resources | object | `{}` |  |

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -47,3 +47,10 @@ The slim suffix will be added to the tag if not present. To disable this behavio
 ## Redis
 
 Please checkout [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
+
+## renovate.configEnableHelmTpl
+Allows you to reference values using `"{{ .Values.someValue }}"` in your config
+
+**NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to
+escape your config entries containing `{{` (i.e. `"key": "{{depName}}"`) in the
+value by wrapping it like: `"key": "{{ "{{depName}}" }}"`.

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -48,7 +48,9 @@ The slim suffix will be added to the tag if not present. To disable this behavio
 
 Please checkout [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
 
-## renovate.configEnableHelmTpl
+## Renovate config templating
+
+Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
 Allows you to reference values using `"{{ .Values.someValue }}"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to

--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,5 +7,9 @@ metadata:
     {{- include "renovate.labels" . | nindent 4 }}
 data:
   config.json: |-
+  {{- if not .Values.renovate.configEnableHelmTpl }}
+    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" .Values.renovate.config | nindent 4 }}
+  {{- else }}
     {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" (tpl .Values.renovate.config .) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "renovate.labels" . | nindent 4 }}
 data:
   config.json: |-
-    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" tpl .Values.renovate.config | nindent 4 }}
+    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" (tpl .Values.renovate.config) | nindent 4 }}
 {{- end }}

--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "renovate.labels" . | nindent 4 }}
 data:
   config.json: |-
-    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" .Values.renovate.config | nindent 4 }}
+    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" tpl .Values.renovate.config | nindent 4 }}
 {{- end }}

--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "renovate.labels" . | nindent 4 }}
 data:
   config.json: |-
-    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" (tpl .Values.renovate.config) | nindent 4 }}
+    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" (tpl .Values.renovate.config .) | nindent 4 }}
 {{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -57,6 +57,13 @@ renovate:
   #     "repositories": ["username/repo", "orgname/repo"]
   #   }
 
+  # -- Use the Helm tpl function on your configuration
+  # Allows you to reference values using "{{ .Values.someValue }}" in your config
+  # NOTE: using this means that you have to escape your config entries in the config
+  # key above containing {{ in the value by wrapping it like this:
+  # "key": "{{ "{{depName}}" }}"
+  configEnableHelmTpl: false
+
   # -- Renovate Container-level security-context
   securityContext: {}
 

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -57,11 +57,7 @@ renovate:
   #     "repositories": ["username/repo", "orgname/repo"]
   #   }
 
-  # -- Use the Helm tpl function on your configuration
-  # Allows you to reference values using "{{ .Values.someValue }}" in your config
-  # NOTE: using this means that you have to escape your config entries in the config
-  # key above containing {{ in the value by wrapping it like this:
-  # "key": "{{ "{{depName}}" }}"
+  # -- Use the Helm tpl function on your configuration. See README for how to use this value
   configEnableHelmTpl: false
 
   # -- Renovate Container-level security-context


### PR DESCRIPTION
We use [helm secrets](https://github.com/jkroepke/helm-secrets) to encrypt configuration values like credentials. To reference these it would be nice to be able to reference these in the configuration without creating a custom configmap. To allow for this the tpl function has been added in this PR.