### PR TITLE
Added support for ttlSecondsAfterFinished on the job spec

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.startingDeadlineSeconds | string | `""` |  |
 | cronjob.successfulJobsHistoryLimit | string | `""` |  |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
+| cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |
 | dind.image.pullPolicy | string | `"IfNotPresent"` |  |
 | dind.image.repository | string | `"docker"` |  |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -41,6 +41,9 @@ spec:
       labels:
         {{- include "renovate.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.cronjob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished }}
+      {{- end }}
       {{- if .Values.cronjob.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ .Values.cronjob.activeDeadlineSeconds }}
       {{- end }}
@@ -76,12 +79,12 @@ spec:
               {{- if or .Values.dind.enabled .Values.cronjob.preCommand}}
               command: ["/bin/bash", "-c"]
               args:
-                - | 
-                {{- if .Values.dind.enabled }} 
+                - |
+                {{- if .Values.dind.enabled }}
                   trap "touch /tmp/main-terminated" EXIT
                   while true; do if [[ -f "/tmp/dind-started" ]]; then break; fi; sleep 1; done
                 {{- end }}
-                {{- if .Values.cronjob.preCommand }} 
+                {{- if .Values.cronjob.preCommand }}
                   {{- .Values.cronjob.preCommand | nindent 18 }}
                 {{- end }}
                   renovate

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -13,6 +13,8 @@ cronjob:
   failedJobsHistoryLimit: ''
   successfulJobsHistoryLimit: ''
   jobRestartPolicy: Never
+  # -- Time to keep the job after it finished before automatically deleting it
+  ttlSecondsAfterFinished: ''
   # -- Deadline for the job to finish
   activeDeadlineSeconds: ''
   jobBackoffLimit: ''


### PR DESCRIPTION
Closes #244

As described in the issue, none of the major cloud providers supports k8s 1.20 anymore, therefore I think it's no longer necessary to support 1.20. That's why I also removed 1.20 from the workflow check in this PR