### PR TITLE
ci: Removed k8s 1.21 checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,6 @@ jobs:
       matrix:
         k8s:
           # from https://github.com/yannh/kubernetes-json-schema
-          - v1.21.13
           - v1.22.10
           - v1.23.7
           - v1.24.1
@@ -84,7 +83,6 @@ jobs:
       matrix:
         k8s:
           # from https://hub.docker.com/r/kindest/node/tags
-          - v1.21.12 # renovate: kindest
           - v1.22.15 # renovate: kindest
           - v1.23.6 # renovate: kindest
           - v1.24.7 # renovate: kindest


### PR DESCRIPTION
Already created PR to remove k8s 1.21 checks for when GKE and EKS 1.21 versions are EOL. 

These are the EOL dates for the EKS, GKE and, AKS 1.21:

| Provider (1.21) | EOL date            |
|---------------|-----------------|
| EKS                  | 2023-02-15       |
| GKE                 | 2023-01-31        |
| AKS                 | 2022-07-31        |

Sources:

- [EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [GKE](https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule-for-release-channels)
- [AKS](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)