### PR TITLE
docs: Document all config values

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -38,20 +38,20 @@ The following table lists the configurable parameters of the chart and the defau
 ## Values
 
 | Key | Type | Default | Description |
-|-----|------|---------|-------------|
+|-----|------|-------|-------------|
 | apiVersionOverrides.cronjob | string | `""` | String to override apiVersion of cronjob rendered by this helm chart |
 | cronjob.activeDeadlineSeconds | string | `""` | Deadline for the job to finish |
-| cronjob.annotations | object | `{}` |  |
-| cronjob.concurrencyPolicy | string | `""` |  |
-| cronjob.failedJobsHistoryLimit | string | `""` |  |
+| cronjob.annotations | object | `{}` | Annotations to set on the cronjob |
+| cronjob.concurrencyPolicy | string | `""` | Set to Allow to allow concurrent runs, Forbid to skip new runs if a previous run is still running or Replace to replace the previous run |
+| cronjob.failedJobsHistoryLimit | string | `""` | Amount of failed jobs to keep in history |
 | cronjob.initContainers | list | `[]` | Additional initContainers that can be executed before renovate |
-| cronjob.jobBackoffLimit | string | `""` |  |
-| cronjob.jobRestartPolicy | string | `"Never"` |  |
-| cronjob.labels | object | `{}` |  |
+| cronjob.jobBackoffLimit | string | `""` | Number of times to retry an errored job before considering it as being failed |
+| cronjob.jobRestartPolicy | string | `"Never"` | Set to Never to restart the job when the pod fails or to OnFailure to restart when a container fails |
+| cronjob.labels | object | `{}` | Labels to set on the cronjob |
 | cronjob.preCommand | string | `""` | Prepend shell commands before renovate runs |
-| cronjob.schedule | string | `"0 1 * * *"` |  |
-| cronjob.startingDeadlineSeconds | string | `""` |  |
-| cronjob.successfulJobsHistoryLimit | string | `""` |  |
+| cronjob.schedule | string | `"0 1 * * *"` | Schedules the job to run using cron notation |
+| cronjob.startingDeadlineSeconds | string | `""` | Deadline to start the job, skips execution if job misses it's configured deadline |
+| cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
 | cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |
@@ -67,18 +67,21 @@ The following table lists the configurable parameters of the chart and the defau
 | extraConfigmaps | list | `[]` | Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to the container |
 | extraVolumes | list | `[]` | Additional volumes to the pod |
+| fullnameOverride | string | `""` | Override the fully qualified app name |
 | global.commonLabels | object | `{}` | Additional labels to be set on all renovate resources |
 | hostAliases | list | `[]` | Override hostname resolution |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"renovate/renovate"` |  |
 | image.tag | string | `"34.108.2"` |  |
 | imagePullSecrets | object | `{}` |  |
-| pod.annotations | object | `{}` |  |
-| pod.labels | object | `{}` |  |
+| nameOverride | string | `""` | Override the name of the chart |
+| pod.annotations | object | `{}` | Annotations to set on the pod |
+| pod.labels | object | `{}` | Labels to set on the pod |
 | redis.architecture | string | `"standalone"` | Disable replication by default |
 | redis.auth.enabled | bool | `false` | Don't require a password by default |
 | redis.enabled | bool | `false` | Enable the Redis subchart? |
 | redis.kubeVersion | string | `""` | Override Kubernetes version for redis chart |
+| redis.nameOverride | string | `""` | Override the prefix of the redisHost |
 | renovate.config | string | `""` | Inline global renovate config.json |
 | renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See README for how to use this value |
 | renovate.configIsSecret | bool | `false` | Use this to create the renovate config as a secret instead of a configmap |
@@ -90,9 +93,9 @@ The following table lists the configurable parameters of the chart and the defau
 | resources | object | `{}` |  |
 | secrets | object | `{}` |  |
 | securityContext | object | `{}` | Pod-level security-context |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `false` |  |
-| serviceAccount.name | string | `""` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use |
 | ssh_config.config | string | `""` |  |
 | ssh_config.enabled | bool | `false` |  |
 | ssh_config.existingSecret | string | `""` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the chart and the defau
 | env | object | `{}` |  |
 | envFrom | list | `[]` |  |
 | envList | list | `[]` | Additional env. To helpful if you want to use anything other than a `value` source. |
-| existingSecret | string | `""` |  |
+| existingSecret | string | `""` | k8s secret to reference environment variables from. Overrides secrets if set |
 | extraConfigmaps | list | `[]` | Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to the container |
 | extraVolumes | list | `[]` | Additional volumes to the pod |
@@ -91,7 +91,7 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.persistence.cache.storageSize | string | `"512Mi"` | Storage size of the cache PVC |
 | renovate.securityContext | object | `{}` | Renovate Container-level security-context |
 | resources | object | `{}` |  |
-| secrets | object | `{}` |  |
+| secrets | object | `{}` | Environment variables that should be referenced from a k8s secret, cannot be used when existingSecret is set |
 | securityContext | object | `{}` | Pod-level security-context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -70,10 +70,10 @@ The following table lists the configurable parameters of the chart and the defau
 | fullnameOverride | string | `""` | Override the fully qualified app name |
 | global.commonLabels | object | `{}` | Additional labels to be set on all renovate resources |
 | hostAliases | list | `[]` | Override hostname resolution |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"renovate/renovate"` |  |
-| image.tag | string | `"34.108.2"` |  |
-| imagePullSecrets | object | `{}` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
+| image.repository | string | `"renovate/renovate"` | Repository to pull renovate image from |
+| image.tag | string | `"34.108.2"` | Renovate image tag to pull |
+| imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |
 | pod.annotations | object | `{}` | Annotations to set on the pod |
 | pod.labels | object | `{}` | Labels to set on the pod |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -96,11 +96,11 @@ The following table lists the configurable parameters of the chart and the defau
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use |
-| ssh_config.config | string | `""` |  |
-| ssh_config.enabled | bool | `false` |  |
-| ssh_config.existingSecret | string | `""` |  |
-| ssh_config.id_rsa | string | `""` |  |
-| ssh_config.id_rsa_pub | string | `""` |  |
+| ssh_config.config | string | `""` | Contents of the config file |
+| ssh_config.enabled | bool | `false` | Whether to enable the use and creation of a secret containing .ssh files |
+| ssh_config.existingSecret | string | `""` | Name of the existing secret containing a valid .ssh configuration |
+| ssh_config.id_rsa | string | `""` | Contents of the id_rsa file |
+| ssh_config.id_rsa_pub | string | `""` | Contents of the id_rsa_pub file |
 
 ## Renovate persistent cache
 

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -55,9 +55,9 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
 | cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |
-| dind.image.pullPolicy | string | `"IfNotPresent"` |  |
-| dind.image.repository | string | `"docker"` |  |
-| dind.image.tag | string | `"20.10.23-dind"` |  |
+| dind.image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
+| dind.image.repository | string | `"docker"` | Repository to pull dind image from |
+| dind.image.tag | string | `"20.10.23-dind"` | dind image tag to pull |
 | dind.securityContext | object | `{"privileged":true}` | DinD Container-level security-context. Privilged is needed for DinD, it will not work without! |
 | dind.slim.enabled | bool | `true` | Do not add `-slim` suffix to image tag when using dind |
 | env | object | `{}` |  |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -61,9 +61,9 @@ The following table lists the configurable parameters of the chart and the defau
 | dind.image.tag | string | `"20.10.23-dind"` | dind image tag to pull |
 | dind.securityContext | object | `{"privileged":true}` | DinD Container-level security-context. Privilged is needed for DinD, it will not work without! |
 | dind.slim.enabled | bool | `true` | Do not add `-slim` suffix to image tag when using dind |
-| env | object | `{}` |  |
-| envFrom | list | `[]` |  |
-| envList | list | `[]` | Additional env. To helpful if you want to use anything other than a `value` source. |
+| env | object | `{}` | Environment variables to set on the renovate container |
+| envFrom | list | `[]` | Environment variables to add from existing secrets/configmaps. Uses the keys as variable name |
+| envList | list | `[]` | Additional env. Helpful too if you want to use anything other than a `value` source. |
 | existingSecret | string | `""` | k8s secret to reference environment variables from. Overrides secrets if set |
 | extraConfigmaps | list | `[]` | Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to the container |
@@ -92,7 +92,7 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.persistence.cache.storageClass | string | `""` | Storage class of the cache PVC |
 | renovate.persistence.cache.storageSize | string | `"512Mi"` | Storage size of the cache PVC |
 | renovate.securityContext | object | `{}` | Renovate Container-level security-context |
-| resources | object | `{}` |  |
+| resources | object | `{}` | Specify resource limits and requests for the renovate container |
 | secrets | object | `{}` | Environment variables that should be referenced from a k8s secret, cannot be used when existingSecret is set |
 | securityContext | object | `{}` | Pod-level security-context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters of the chart and the defau
 | apiVersionOverrides.cronjob | string | `""` | String to override apiVersion of cronjob rendered by this helm chart |
 | cronjob.activeDeadlineSeconds | string | `""` | Deadline for the job to finish |
 | cronjob.annotations | object | `{}` | Annotations to set on the cronjob |
-| cronjob.concurrencyPolicy | string | `""` | Set to Allow to allow concurrent runs, Forbid to skip new runs if a previous run is still running or Replace to replace the previous run |
+| cronjob.concurrencyPolicy | string | `""` | "Allow" to allow concurrent runs, "Forbid" to skip new runs if a previous run is still running or "Replace" to replace the previous run |
 | cronjob.failedJobsHistoryLimit | string | `""` | Amount of failed jobs to keep in history |
 | cronjob.initContainers | list | `[]` | Additional initContainers that can be executed before renovate |
 | cronjob.jobBackoffLimit | string | `""` | Number of times to retry an errored job before considering it as being failed |
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the chart and the defau
 | dind.image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | dind.image.repository | string | `"docker"` | Repository to pull dind image from |
 | dind.image.tag | string | `"20.10.23-dind"` | dind image tag to pull |
-| dind.securityContext | object | `{"privileged":true}` | DinD Container-level security-context. Privilged is needed for DinD, it will not work without! |
+| dind.securityContext | object | `{"privileged":true}` | DinD Container-level security-context. Privileged is needed for DinD, it will not work without! |
 | dind.slim.enabled | bool | `true` | Do not add `-slim` suffix to image tag when using dind |
 | env | object | `{}` | Environment variables to set on the renovate container |
 | envFrom | list | `[]` | Environment variables to add from existing secrets/configmaps. Uses the keys as variable name |
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the chart and the defau
 | redis.nameOverride | string | `""` | Override the prefix of the redisHost |
 | renovate.config | string | `""` | Inline global renovate config.json |
 | renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See README for how to use this value |
-| renovate.configIsSecret | bool | `false` | Use this to create the renovate config as a secret instead of a configmap |
+| renovate.configIsSecret | bool | `false` | Use this to create the renovate-config as a secret instead of a configmap |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
 | renovate.persistence.cache.enabled | bool | `false` | Allow the cache to persist between runs |
 | renovate.persistence.cache.storageClass | string | `""` | Storage class of the cache PVC |
@@ -131,5 +131,5 @@ The slim suffix will be added to the tag if not present. To disable this behavio
 
 ## Redis
 
-Please checkout [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
+Please check out [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
 

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -39,6 +39,7 @@ The following table lists the configurable parameters of the chart and the defau
 
 | Key | Type | Default | Description |
 |-----|------|-------|-------------|
+| affinity | object | `{}` | Configure the pod(Anti)Affinity and/or node(Anti)Affinity |
 | apiVersionOverrides.cronjob | string | `""` | String to override apiVersion of cronjob rendered by this helm chart |
 | cronjob.activeDeadlineSeconds | string | `""` | Deadline for the job to finish |
 | cronjob.annotations | object | `{}` | Annotations to set on the cronjob |
@@ -75,6 +76,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.tag | string | `"34.108.2"` | Renovate image tag to pull |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |
+| nodeSelector | object | `{}` | Select the node using labels to specify where the cronjob pod should run on |
 | pod.annotations | object | `{}` | Annotations to set on the pod |
 | pod.labels | object | `{}` | Labels to set on the pod |
 | redis.architecture | string | `"standalone"` | Disable replication by default |
@@ -101,6 +103,7 @@ The following table lists the configurable parameters of the chart and the defau
 | ssh_config.existingSecret | string | `""` | Name of the existing secret containing a valid .ssh configuration |
 | ssh_config.id_rsa | string | `""` | Contents of the id_rsa file |
 | ssh_config.id_rsa_pub | string | `""` | Contents of the id_rsa_pub file |
+| tolerations | list | `[]` | Configure which node taints the pod should tolerate |
 
 ## Renovate persistent cache
 

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -16,7 +16,7 @@ cronjob:
   annotations: {}
   # -- Labels to set on the cronjob
   labels: {}
-  # -- Set to Allow to allow concurrent runs, Forbid to skip new runs if a previous run is still running or Replace to replace the previous run
+  # -- "Allow" to allow concurrent runs, "Forbid" to skip new runs if a previous run is still running or "Replace" to replace the previous run
   concurrencyPolicy: ''
   # -- Amount of failed jobs to keep in history
   failedJobsHistoryLimit: ''
@@ -81,7 +81,7 @@ renovate:
   # -- Use the Helm tpl function on your configuration. See README for how to use this value
   configEnableHelmTpl: false
 
-  # -- Use this to create the renovate config as a secret instead of a configmap
+  # -- Use this to create the renovate-config as a secret instead of a configmap
   configIsSecret: false
 
   # -- Renovate Container-level security-context

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -117,11 +117,14 @@ dind:
     # -- Do not add `-slim` suffix to image tag when using dind
     enabled: true
   image:
+    # -- Repository to pull dind image from
     repository: docker
+    # -- dind image tag to pull
     tag: 20.10.23-dind
+    # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
     pullPolicy: IfNotPresent
 
-  # -- DinD Container-level security-context. Privilged is needed for DinD, it will not work without!
+  # -- DinD Container-level security-context. Privileged is needed for DinD, it will not work without!
   securityContext:
     privileged: true
 

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -113,9 +113,9 @@ ssh_config:
   # -- Name of the existing secret containing a valid .ssh configuration
   existingSecret: ''
 
-# Provide secrets inline
+# -- Environment variables that should be referenced from a k8s secret, cannot be used when existingSecret is set
 secrets: {}
-# or provide the name of an existing secret to be read instead.
+# -- k8s secret to reference environment variables from. Overrides secrets if set
 existingSecret: ''
 
 dind:

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -51,10 +51,14 @@ pod:
   labels: {}
 
 image:
+  # -- Repository to pull renovate image from
   repository: renovate/renovate
+  # -- Renovate image tag to pull
   tag: 34.108.2
+  # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
 
+# -- Secret to use to pull the image from the repository
 imagePullSecrets: {}
 
 renovate:

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -174,6 +174,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ''
 
+# -- Specify resource limits and requests for the renovate container
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -186,11 +187,18 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+# -- Environment variables to add from existing secrets/configmaps. Uses the keys as variable name
 envFrom: []
+# envFrom:
+#   - secretRef:
+#     name: env-secrets
+#   - configMapRef:
+#     name: env-configmap
 
+# -- Environment variables to set on the renovate container
 env: {}
 
-# -- Additional env. To helpful if you want to use anything other than a `value` source.
+# -- Additional env. Helpful too if you want to use anything other than a `value` source.
 envList: []
 # envList:
 #   - name: POD_NAME
@@ -199,7 +207,7 @@ envList: []
 #         fieldPath: metadata.name
 
 redis:
-  # Configuration for a Redis subchart. Additional documenation at
+  # Configuration for a Redis subchart. Additional documentation at
   # https://github.com/bitnami/charts/tree/master/bitnami/redis
 
   # -- Enable the Redis subchart?

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -236,6 +236,15 @@ hostAliases: []
 # -- Pod-level security-context
 securityContext: {}
 
-nodeSelector: ''
-affinity: ''
-tolerations: ''
+# -- Select the node using labels to specify where the cronjob pod should run on
+nodeSelector: {}
+# See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+# renovate: true
+
+# -- Configure the pod(Anti)Affinity and/or node(Anti)Affinity
+affinity: {}
+# See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+
+# -- Configure which node taints the pod should tolerate
+tolerations: []
+# See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -98,13 +98,21 @@ renovate:
       storageSize: "512Mi"
 
 ssh_config:
+  # -- Whether to enable the use and creation of a secret containing .ssh files
   enabled: false
+
   # Provide .ssh config file contents
+  # -- Contents of the id_rsa file
   id_rsa: ''
+  # -- Contents of the id_rsa_pub file
   id_rsa_pub: ''
+  # -- Contents of the config file
   config: ''
+
   # or provide the name of an existing secret to be read instead.
+  # -- Name of the existing secret containing a valid .ssh configuration
   existingSecret: ''
+
 # Provide secrets inline
 secrets: {}
 # or provide the name of an existing secret to be read instead.

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -2,22 +2,35 @@ global:
   # -- Additional labels to be set on all renovate resources
   commonLabels: {}
 
+# -- Override the name of the chart
+nameOverride: ''
+# -- Override the fully qualified app name
+fullnameOverride: ''
+
 cronjob:
-  # At 01:00 every day
-  schedule: '0 1 * * *'
+  # -- Schedules the job to run using cron notation
+  schedule: '0 1 * * *' # At 01:00 every day
   # -- If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions.
   suspend: false
+  # -- Annotations to set on the cronjob
   annotations: {}
+  # -- Labels to set on the cronjob
   labels: {}
+  # -- Set to Allow to allow concurrent runs, Forbid to skip new runs if a previous run is still running or Replace to replace the previous run
   concurrencyPolicy: ''
+  # -- Amount of failed jobs to keep in history
   failedJobsHistoryLimit: ''
+  # -- Amount of completed jobs to keep in history
   successfulJobsHistoryLimit: ''
+  # -- Set to Never to restart the job when the pod fails or to OnFailure to restart when a container fails
   jobRestartPolicy: Never
   # -- Time to keep the job after it finished before automatically deleting it
   ttlSecondsAfterFinished: ''
   # -- Deadline for the job to finish
   activeDeadlineSeconds: ''
+  # -- Number of times to retry running the pod before considering the job as being failed
   jobBackoffLimit: ''
+  # -- Deadline to start the job, skips execution if job misses it's configured deadline
   startingDeadlineSeconds: ''
   # -- Additional initContainers that can be executed before renovate
   initContainers: []
@@ -32,7 +45,9 @@ cronjob:
   #   echo world
 
 pod:
+  # -- Annotations to set on the pod
   annotations: {}
+  # -- Labels to set on the pod
   labels: {}
 
 image:
@@ -136,11 +151,11 @@ extraVolumeMounts: []
 #     subPath: .netrc
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: false
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use
   # If not set and create is true, a name is generated using the fullname template
   name: ''
 
@@ -175,6 +190,9 @@ redis:
   # -- Enable the Redis subchart?
   enabled: false
 
+  # -- Override the prefix of the redisHost
+  nameOverride: ''
+
   # -- Disable replication by default
   architecture: standalone
 
@@ -202,3 +220,7 @@ hostAliases: []
 
 # -- Pod-level security-context
 securityContext: {}
+
+nodeSelector: ''
+affinity: ''
+tolerations: ''

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -9,7 +9,7 @@ fullnameOverride: ''
 
 cronjob:
   # -- Schedules the job to run using cron notation
-  schedule: '0 1 * * *' # At 01:00 every day
+  schedule: '0 1 * * *'  # At 01:00 every day
   # -- If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions.
   suspend: false
   # -- Annotations to set on the cronjob


### PR DESCRIPTION
Closes #160

Checked all the missing values using my IDE (which were `nameOverride`, `fullnameOverride`, `nodeSelector`, `affinity`, and `tolerations`. Also documented all values that were already in `values.yaml` but had no documentation comment associated with them.

I saw no activity on #242 so decided to start over myself