### PR TITLE
feat: ability to run arbitrary postCommand and sidecar extraContainers

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the chart and the defau
 | extraConfigmaps | list | `[]` | Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to the container |
 | extraVolumes | list | `[]` | Additional volumes to the pod |
+| extraContainers | list | `[]` | Additional containers to the pod |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
 | global.commonLabels | object | `{}` | Additional labels to be set on all renovate resources |
 | hostAliases | list | `[]` | Override hostname resolution |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.jobRestartPolicy | string | `"Never"` | Set to Never to restart the job when the pod fails or to OnFailure to restart when a container fails |
 | cronjob.labels | object | `{}` | Labels to set on the cronjob |
 | cronjob.preCommand | string | `""` | Prepend shell commands before renovate runs |
+| cronjob.postCommand | string | `""` | Append shell commands after renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` | Schedules the job to run using cron notation |
 | cronjob.startingDeadlineSeconds | string | `""` | Deadline to start the job, skips execution if job misses it's configured deadline |
 | cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -76,7 +76,7 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ include "renovate.imageTag" . }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              {{- if or .Values.dind.enabled .Values.cronjob.preCommand}}
+              {{- if or .Values.dind.enabled .Values.cronjob.preCommand .Values.cronjob.postCommand}}
               command: ["/bin/bash", "-c"]
               args:
                 - |
@@ -88,6 +88,9 @@ spec:
                   {{- .Values.cronjob.preCommand | nindent 18 }}
                 {{- end }}
                   renovate
+                {{- if .Values.cronjob.postCommand }}
+                  {{- .Values.cronjob.postCommand | nindent 18 }}
+                {{- end }}
               {{- end }}
               {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.dind.enabled .Values.extraVolumes }}
               volumeMounts:

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -181,6 +181,9 @@ spec:
                 - name: {{ .Chart.Name }}-tmp-volume
                   mountPath: /tmp
             {{- end }}
+          {{- with .Values.extraContainers }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           volumes:
             {{- if .Values.renovate.config }}
               {{- if .Values.renovate.configIsSecret }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -165,6 +165,23 @@ extraVolumeMounts: []
 #     mountPath: /home/ubuntu/.netrc
 #     subPath: .netrc
 
+# -- Additional containers to the pod
+extraContainers: []
+# extraContainers:
+#   - name: vault-agent
+#     image: vault:1.6.2
+#     args:
+#     - agent
+#     - -config
+#     - /vault/config/config.hcl
+#     env:
+#     - name: VAULT_ADDR
+#       value: https://vault:8200
+#     - name: VAULT_SKIP_VERIFY
+#       value: "false"
+#     - name: VAULT_CACERT
+#       value: /vault/tls/ca.crt
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: false

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -44,6 +44,12 @@ cronjob:
   #   echo hello
   #   echo world
 
+  # -- Append shell commands after renovate runs
+  postCommand: ''
+  # postCommand: |
+  #   echo hello
+  #   echo world
+
 pod:
   # -- Annotations to set on the pod
   annotations: {}


### PR DESCRIPTION
When running renovatebot self-hosted using Githup App credentials, we currently have to manually approve each PR despite our auto merge and label settings. Our CI system applies the label `needs-ok-to-test` to any PR created by users outside our Github org. We need the ability to run an arbitrary sidecar container so that we can use the gh cli in a postStop hook. I'm sure other folks have use-cases for other sidecars such as cloudsql or manually-defined istio. for example:
```yaml
  postCommand: |
    curl -s -L --retry 5 \
      https://github.com/cli/cli/releases/download/v2.23.0/gh_2.23.0_linux_amd64.tar.gz \
      | tar zxvf - -C /usr/local/bin \
        gh_2.23.0_linux_amd64/bin/gh \
        --strip-components=2 
    chmod +x /usr/local/bin/gh
    gh search prs --state=open \
    --label 'renovatebot' \
    --label 'updatebot' \
    --label 'needs-ok-to-test' \
    --app 'renovatebot-{{ .Release.Name }}' \
    --owner {{ .Release.Name }} \
    --json url \
    --jq '.[].url' | while read -r url; do
      gh pr edit --remove-label needs-ok-to-test "$url"
    done
```

```yaml
extraContainers:
  - name: remove-ok-to-test-label
    image: ghcr.io/supportpal/github-gh-cli:2.23.0
    # logic in the command: to terminate after renovatebot pid
    lifecycle:
      preStop:
        exec:
          command:
            - /bin/sh
            - '-c'
            - |
              gh search prs --state=open \
              --label 'renovatebot' \
              --label 'updatebot' \
              --label 'needs-ok-to-test' \
              --app 'renovatebot-{{ .Release.Name }}' \
              --owner {{ .Release.Name }} \
              --json url \
              --jq '.[].url' | while read -r url; do
                gh pr edit --remove-label needs-ok-to-test "$url"
              done
```


mostly copied from the common pattern at https://github.com/argoproj/argo-helm/blob/c08fc230d75c85b2c9a07138c5c7b7bc957b98df/charts/argo-cd/templates/argocd-repo-server/deployment.yaml