### PR TITLE
allow slim config without dind

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -36,9 +36,8 @@ fi
 
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
-  VALUES_FILES=$(ls "./charts/${CHART_DIR}/ci/*.yaml")
-  for VALUES_FILE in ${VALUES_FILES}; do
-    (cd "charts/${CHART_DIR}"; helm dependency build)
+  (cd "charts/${CHART_DIR}"; helm dependency build)
+  for VALUES_FILE in charts/"${CHART_DIR}"/ci/*.yaml; do
     helm template \
       "${apis[@]}" \
       --values "${VALUES_FILE}" \
@@ -47,5 +46,5 @@ for CHART_DIR in ${CHART_DIRS}; do
         --ignore-missing-schemas \
         --kubernetes-version "${KUBERNETES_VERSION#v}" \
         --schema-location "${SCHEMA_LOCATION}"
-    done
+  done
 done

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -36,13 +36,16 @@ fi
 
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
-  (cd "charts/${CHART_DIR}"; helm dependency build)
-  helm template \
-    "${apis[@]}" \
-    --values charts/"${CHART_DIR}"/ci/ci-values.yaml \
-    charts/"${CHART_DIR}" | kubeval \
-      --strict \
-      --ignore-missing-schemas \
-      --kubernetes-version "${KUBERNETES_VERSION#v}" \
-      --schema-location "${SCHEMA_LOCATION}"
+  VALUES_FILES=$(ls "./charts/${CHART_DIR}/ci/*.yaml")
+  for VALUES_FILE in ${VALUES_FILES}; do
+    (cd "charts/${CHART_DIR}"; helm dependency build)
+    helm template \
+      "${apis[@]}" \
+      --values "${VALUES_FILE}" \
+      charts/"${CHART_DIR}" | kubeval \
+        --strict \
+        --ignore-missing-schemas \
+        --kubernetes-version "${KUBERNETES_VERSION#v}" \
+        --schema-location "${SCHEMA_LOCATION}"
+    done
 done

--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mkdir ./.bin
+mkdir -p ./.bin
 export PATH="./.bin:$PATH"
 
 set -euxo pipefail

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
 | cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
+| slim.enabled | bool | `false` | Do not add `-slim` suffix to image tag |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |
 | dind.image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | dind.image.repository | string | `"docker"` | Repository to pull dind image from |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
 | cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
-| slim.enabled | bool | `false` | Do not add `-slim` suffix to image tag |
+| slim | bool | `false` | Do not add `-slim` suffix to image tag |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |
 | dind.image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | dind.image.repository | string | `"docker"` | Repository to pull dind image from |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
 | cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
-| slim | bool | `false` | Add `-slim` suffix to image tag |
+| slim | bool | `false` | Add `-slim` suffix to image tag and `binarySource=install` |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |
 | dind.image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | dind.image.repository | string | `"docker"` | Repository to pull dind image from |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
 | cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
-| slim | bool | `false` | Do not add `-slim` suffix to image tag |
+| slim | bool | `false` | Add `-slim` suffix to image tag |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |
 | dind.image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | dind.image.repository | string | `"docker"` | Repository to pull dind image from |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -132,6 +132,10 @@ When `dind.enabled` is set to `true`, a Docker in Docker container will run as a
 
 The slim suffix will be added to the tag if not present. To disable this behaviour, set `dind.slim.enabled` to `false`.
 
+## slim configuration without Docker in Docker
+
+When `slim` is set to `true`, the slim suffix will be added to the tag if not present. This also sets the configuration `binarySource` to `install`.
+
 ## Redis
 
 Please check out [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.

--- a/charts/renovate/ci/ci-slim-without-dind.yaml
+++ b/charts/renovate/ci/ci-slim-without-dind.yaml
@@ -1,0 +1,30 @@
+imagePullSecrets:
+  - name: myregistrykey
+envFrom:
+  - configMapRef:
+      name: my-config
+secrets:
+  my-secret-1: |
+    123
+  my-secret-2: |
+    456
+ssh_config:
+  enabled: true
+  config: |
+    Host *
+      ForwardAgent yes
+renovate:
+  config: |
+    {
+      "platform": "gitlab",
+      "endpoint": "https://gitlab.example.com/api/v4",
+      "token": "your-gitlab-renovate-user-token",
+      "autodiscover": "false",
+      "dryRun": true,
+      "printConfig": true,
+      "logLevel": "debug",
+      "repositories": ["username/repo", "orgname/repo"]
+    }
+
+slim:
+  enabled: true

--- a/charts/renovate/ci/ci-slim-without-dind.yaml
+++ b/charts/renovate/ci/ci-slim-without-dind.yaml
@@ -26,5 +26,4 @@ renovate:
       "repositories": ["username/repo", "orgname/repo"]
     }
 
-slim:
-  enabled: true
+slim: true

--- a/charts/renovate/templates/_helpers.tpl
+++ b/charts/renovate/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Define ssh config secret
 Force slim image if dind is enabled and slim is not disabled
 */}}
 {{- define "renovate.imageTag" -}}
-{{- if and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) (not (regexMatch "^.*-slim$" .Values.image.tag)) -}}
+{{- if or .Values.slim.enabled (and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) (not (regexMatch "^.*-slim$" .Values.image.tag))) -}}
 {{- .Values.image.tag }}-slim
 {{- else -}}
 {{- .Values.image.tag }}

--- a/charts/renovate/templates/_helpers.tpl
+++ b/charts/renovate/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Define ssh config secret
 Force slim image if dind is enabled and slim is not disabled
 */}}
 {{- define "renovate.imageTag" -}}
-{{- if or .Values.slim.enabled (and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) (not (regexMatch "^.*-slim$" .Values.image.tag))) -}}
+{{- if or .Values.slim (and .Values.dind.enabled .Values.dind.slim.enabled (not (eq .Values.image.tag "slim")) (not (regexMatch "^.*-slim$" .Values.image.tag))) -}}
 {{- .Values.image.tag }}-slim
 {{- else -}}
 {{- .Values.image.tag }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -128,6 +128,10 @@ spec:
                 - name: RENOVATE_REDIS_URL
                   value: redis://{{ include "renovate.redisHost" . }}
                 {{- end }}
+                {{- if .Values.slim.enabled }}
+                - name: RENOVATE_BINARY_SOURCE
+                  value: install
+                {{- end }}
                 {{- range $k, $v := .Values.env }}
                 - name: {{ $k | quote }}
                   value: {{ $v | quote }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -128,7 +128,7 @@ spec:
                 - name: RENOVATE_REDIS_URL
                   value: redis://{{ include "renovate.redisHost" . }}
                 {{- end }}
-                {{- if .Values.slim.enabled }}
+                {{- if .Values.slim }}
                 - name: RENOVATE_BINARY_SOURCE
                   value: install
                 {{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -64,6 +64,10 @@ image:
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
 
+slim:
+  # -- Do not add `-slim` suffix to image tag
+  enabled: false
+
 # -- Secret to use to pull the image from the repository
 imagePullSecrets: {}
 

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -64,7 +64,7 @@ image:
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
 
-# -- Add `-slim` suffix to image tag
+# -- Add `-slim` suffix to image tag and `binarySource=install`
 slim: false
 
 # -- Secret to use to pull the image from the repository

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -64,9 +64,8 @@ image:
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
 
-slim:
-  # -- Do not add `-slim` suffix to image tag
-  enabled: false
+# -- Add `-slim` suffix to image tag
+slim: false
 
 # -- Secret to use to pull the image from the repository
 imagePullSecrets: {}


### PR DESCRIPTION
- closes #281

* allow `slim.enabled: true` to allow slim images without dind, defaults to `false`
* updated readme
* add `ci/ci-slim-without-dind.yaml` test values
* update `.github/kubeval.sh` to test all k8s versions with all test values files
* set `RENOVATE_BINARY_SOURCE` env to `install` if new slim switch is enabled