### PR TITLE
Add option to configure registry mirror

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -170,7 +170,7 @@ spec:
               command: ["/bin/sh", "-c"]
               args:
                 - |
-                  dockerd-entrypoint.sh &
+                  dockerd-entrypoint.sh {{ range $mirror := .Values.dind.registryMirrors }}--registry-mirror {{ $mirror | quote }} {{ end }} &
                   CHILD_PID=$!
                   while ! (pgrep containerd); do sleep 1; done
                   touch /tmp/dind-started

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -145,6 +145,9 @@ dind:
   securityContext:
     privileged: true
 
+  # -- Set registry mirrors to use as pull cache
+  registryMirrors: []
+
 # -- Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config
 extraConfigmaps: []
 # extraConfigmaps:


### PR DESCRIPTION
Adds `dind.registryMirrors` array that can be used configure docker registry cache

Closes #277