### PR TITLE
fix: Revert "chore(deps): update dependency docker to v20.10.25"

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/containerbase/base:7.10.0
 COPY tools/*.sh /usr/local/buildpack/tools/
 
 # renovate: datasource=github-releases depName=docker packageName=moby/moby
-ARG DOCKER_VERSION=v20.10.25
+ARG DOCKER_VERSION=v20.10.24
 RUN install-tool docker
 
 # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl


### PR DESCRIPTION
Release not available.

Reverts renovatebot/helm-charts#294