### PR TITLE
ci: stop testing on k8s v1.22 and v1.23

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,8 +6,8 @@ COPY tools/*.sh /usr/local/buildpack/tools/
 ARG DOCKER_VERSION=v23.0.6
 RUN install-tool docker
 
-# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl
-ARG KUBECTL_VERSION=1.24.1
+# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes
+ARG KUBECTL_VERSION=1.27.1
 RUN install-tool kubectl
 
 # renovate: datasource=github-releases depName=kind packageName=kubernetes-sigs/kind

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,6 @@ jobs:
       matrix:
         k8s:
           # from https://github.com/yannh/kubernetes-json-schema
-          - v1.22.17
-          - v1.23.17
           - v1.24.13
           - v1.25.9
           - v1.26.4
@@ -84,11 +82,9 @@ jobs:
       matrix:
         k8s:
           # from https://hub.docker.com/r/kindest/node/tags
-          - v1.22.17 # renovate: kindest
-          - v1.23.17 # renovate: kindest
-          - v1.24.12 # renovate: kindest
-          - v1.25.8 # renovate: kindest
-          - v1.26.3 # renovate: kindest
+          - v1.24.13 # renovate: kindest
+          - v1.25.9 # renovate: kindest
+          - v1.26.4 # renovate: kindest
           - v1.27.1 # renovate: kindest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Chart documentation is automatically generated using [helm-docs](https://github.
 We test the four latest versions of Kubernetes.
 The general concept is that we track the versions of Kubernetes that are supported by the major cloud providers.
 
+- [Amazon Elastic Kubernetes Service (Amazon EKS)](https://endoflife.date/amazon-eks)
+- [Azure Kubernetes Service (AKS)](https://endoflife.date/azure-kubernetes-service)
+- [Google Kubernetes Engine (GKE)](https://endoflife.date/google-kubernetes-engine)
+
 ## Add Helm repository
 
 ```bash


### PR DESCRIPTION
A couple other fixes related to versions:

- Renovate `packageName` for `kubectl`
- Add endoflife.date links to the README
- Bump `kindest` tags

Closes #296