### PR TITLE
feat: allow setting timeZone for CronJob Schedule

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.startingDeadlineSeconds | string | `""` | Deadline to start the job, skips execution if job misses it's configured deadline |
 | cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
+| cronJob.timeZone | string | `""` | You can specify a time zone for a CronJob by setting timeZone to the name of a valid time zone. (starting with k8s 1.27) https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones |
 | cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
 | slim | bool | `false` | Add `-slim` suffix to image tag and `binarySource=install` |
 | dind.enabled | bool | `false` | Enable dind sidecar usage? |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -21,6 +21,9 @@ metadata:
 {{- end }}
 spec:
   schedule: "{{ .Values.cronjob.schedule }}"
+  {{- with .Values.cronjob.timeZone }}
+  timeZone: {{ . }}
+  {{- end }}
   {{- with .Values.cronjob.suspend }}
   suspend: {{ . }}
   {{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -10,6 +10,8 @@ fullnameOverride: ''
 cronjob:
   # -- Schedules the job to run using cron notation
   schedule: '0 1 * * *'  # At 01:00 every day
+  # -- You can specify a time zone for a CronJob by setting timeZone to the name of a valid time zone. (starting with k8s 1.27) https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+  timeZone: ''  # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for valid names
   # -- If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions.
   suspend: false
   # -- Annotations to set on the cronjob


### PR DESCRIPTION
Starting with kubernetes 1.27 CornJobs support setting a timeZone to be used with the cron expression.

This PR allows setting this timeZone optionally.

See: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones