### PR TITLE
fix: Revert "chore(deps): update dependency chart-testing to v3.9.0"

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,7 @@ ARG HELM_VERSION=v3.12.1
 RUN install-tool helm
 
 # renovate: datasource=github-releases depName=chart-testing packageName=helm/chart-testing
-ARG CHART_TESTING_VERSION=v3.9.0
+ARG CHART_TESTING_VERSION=v3.8.0
 RUN install-tool chart-testing
 
 # renovate: datasource=github-releases depName=helm-docs packageName=norwoodj/helm-docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install chart-testing
         uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # v2.4.0
         with:
-          version: v3.9.0 # renovate: datasource=github-releases depName=chart-testing packageName=helm/chart-testing
+          version: v3.8.0 # renovate: datasource=github-releases depName=chart-testing packageName=helm/chart-testing
 
       - name: Run lint
         run: ct lint --config .github/ct.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Install chart-testing
         uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # v2.4.0
         with:
-          version: v3.9.0 # renovate: datasource=github-releases depName=chart-testing packageName=helm/chart-testing
+          version: v3.8.0 # renovate: datasource=github-releases depName=chart-testing packageName=helm/chart-testing
 
       - name: Run chart install
         run: ct install --config .github/ct.yaml


### PR DESCRIPTION
Reverts renovatebot/helm-charts#317

- https://github.com/helm/chart-testing/issues/577