### PR TITLE
fix: Change variable for `volumeMounts` to the correct one

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -91,7 +91,7 @@ spec:
                   {{- .Values.cronjob.postCommand | nindent 18 }}
                 {{- end }}
               {{- end }}
-              {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.extraVolumes }}
+              {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.extraVolumeMounts }}
               volumeMounts:
               {{- if .Values.renovate.config }}
               - name: config-volume


### PR DESCRIPTION
Current variable for container's volume mounts condition is invalid.
`extraVolumes` is used for `spec.volumes` and `extraVolumeMounts` should be used for `spec.containers[0].volumeMounts`.