### PR TITLE
ci(ct): remove unsupported flag

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,4 +1,4 @@
-helm-extra-args: --timeout 600s
+helm-extra-args:
 check-version-increment: false
 debug: true
 target-branch: main


### PR DESCRIPTION
The new CT added forwarding of this flag to Helm which in turn does not have this flag.   

As CT only runs on chart changes and not Github Actions ones, the CI checks for the upgrade have been successful.

After CT upgrade: https://github.com/renovatebot/helm-charts/actions/runs/6712778910/job/18243044331?pr=653#step:6:46

Before CT upgrade: https://github.com/renovatebot/helm-charts/actions/runs/6697045682/job/18196081288#step:6:56


We can re add this when this PR is merged https://github.com/helm/chart-testing/pull/605