### PR TITLE
fix:  cache volumeMount

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -103,12 +103,12 @@ spec:
                 mountPath: /home/ubuntu/.ssh
                 readOnly: true
               {{- end }}
+              {{- if .Values.extraVolumeMounts }}
+                {{- toYaml .Values.extraVolumeMounts | nindent 14 }}
+              {{- end }}
               {{- if .Values.renovate.persistence.cache.enabled }}
               - name: {{ include "renovate.fullname" . }}-cache
                 mountPath: /tmp/renovate
-              {{- end }}
-              {{- if .Values.extraVolumeMounts }}
-                {{- toYaml .Values.extraVolumeMounts | nindent 14 }}
               {{- end }}
               {{- end }}
               env:

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -91,7 +91,7 @@ spec:
                   {{- .Values.cronjob.postCommand | nindent 18 }}
                 {{- end }}
               {{- end }}
-              {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.extraVolumeMounts }}
+              {{- if or .Values.renovate.config .Values.ssh_config.enabled .Values.renovate.persistence.cache.enabled .Values.extraVolumeMounts }}
               volumeMounts:
               {{- if .Values.renovate.config }}
               - name: config-volume
@@ -103,13 +103,13 @@ spec:
                 mountPath: /home/ubuntu/.ssh
                 readOnly: true
               {{- end }}
-              {{- if .Values.extraVolumeMounts }}
-                {{- toYaml .Values.extraVolumeMounts | nindent 14 }}
-              {{- end }}
-              {{- end }}
               {{- if .Values.renovate.persistence.cache.enabled }}
               - name: {{ include "renovate.fullname" . }}-cache
                 mountPath: /tmp/renovate
+              {{- end }}
+              {{- if .Values.extraVolumeMounts }}
+                {{- toYaml .Values.extraVolumeMounts | nindent 14 }}
+              {{- end }}
               {{- end }}
               env:
                 {{- if .Values.renovate.existingConfigFile }}


### PR DESCRIPTION
Cache volumeMount was outside of the if-statement, thus it could be added without the `volumeMounts:` key existing