### PR TITLE
fix: wrong identation for example

### DIFF
--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -200,9 +200,9 @@ resources: {}
 envFrom: []
 # envFrom:
 #   - secretRef:
-#     name: env-secrets
+#       name: env-secrets
 #   - configMapRef:
-#     name: env-configmap
+#       name: env-configmap
 
 # -- Environment variables to set on the renovate container
 env: {}


### PR DESCRIPTION
The Chart won't render without the extra whitespaces (when using envFrom). See also https://github.com/renovatebot/helm-charts/blob/main/charts/renovate/ci/ci-values.yaml#L3