### PR TITLE
fix: rename config.json to config.json5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo update
 Using config from a file:
 
 ```bash
-helm install --generate-name --set-file renovate.config=config.json renovate/renovate
+helm install --generate-name --set-file renovate.config=config.json5 renovate/renovate
 ```
 
 Using config from a string:

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -20,7 +20,7 @@ helm repo update
 Using config from a file:
 
 ```bash
-helm install --generate-name --set-file renovate.config=config.json renovate/renovate
+helm install --generate-name --set-file renovate.config=config.json5 renovate/renovate
 ```
 
 Using config from a string:
@@ -82,7 +82,7 @@ The following table lists the configurable parameters of the chart and the defau
 | redis.enabled | bool | `false` | Enable the Redis subchart? |
 | redis.kubeVersion | string | `""` | Override Kubernetes version for redis chart |
 | redis.nameOverride | string | `""` | Override the prefix of the redisHost |
-| renovate.config | string | `""` | Inline global renovate config.json |
+| renovate.config | string | `""` | Inline global renovate config.json5 |
 | renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See README for how to use this value |
 | renovate.configIsSecret | bool | `false` | Use this to create the renovate-config as a secret instead of a configmap |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
@@ -114,7 +114,7 @@ can't write to the mounted PVC. For the current default user (`ubuntu`), the cor
 
 ## Renovate config templating
 
-Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
+Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json5`.
 Allows you to reference values using `"{{ .Values.someValue }}"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -21,7 +21,7 @@ helm repo update
 Using config from a file:
 
 ```bash
-helm install --generate-name --set-file renovate.config=config.json renovate/renovate
+helm install --generate-name --set-file renovate.config=config.json5 renovate/renovate
 ```
 
 Using config from a string:
@@ -49,7 +49,7 @@ can't write to the mounted PVC. For the current default user (`ubuntu`), the cor
 
 ## Renovate config templating
 
-Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
+Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json5`.
 Allows you to reference values using `"{{ .Values.someValue }}"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to

--- a/charts/renovate/templates/config.yaml
+++ b/charts/renovate/templates/config.yaml
@@ -15,7 +15,7 @@ stringData:
 {{- else }}
 data:
 {{- end }}
-  config.json: |-
+  config.json5: |-
   {{- if not .Values.renovate.configEnableHelmTpl }}
     {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" .Values.renovate.config | nindent 4 }}
   {{- else }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -95,8 +95,8 @@ spec:
               volumeMounts:
               {{- if .Values.renovate.config }}
               - name: config-volume
-                mountPath: /usr/src/app/config.json
-                subPath: config.json
+                mountPath: /usr/src/app/config.json5
+                subPath: config.json5
               {{- end }}
               {{- if .Values.ssh_config.enabled }}
               - name: ssh-config-volume
@@ -117,7 +117,7 @@ spec:
                   value: {{ .Values.renovate.existingConfigFile }}
                 {{- else if .Values.renovate.config }}
                 - name: RENOVATE_CONFIG_FILE
-                  value: /usr/src/app/config.json
+                  value: /usr/src/app/config.json5
                 {{- end }}
                 {{- if .Values.redis.enabled }}
                 - name: RENOVATE_REDIS_URL

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -74,7 +74,7 @@ imagePullSecrets: {}
 renovate:
   # -- Custom exiting global renovate config
   existingConfigFile: ''
-  # -- Inline global renovate config.json
+  # -- Inline global renovate config.json5
   config: ''
   # See https://docs.renovatebot.com/self-hosted-configuration
   # config: |


### PR DESCRIPTION
Renovate logs show:
WARN: File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.
       "context": "/usr/src/app/config.json"

Therefore this renames all occurrences of config.json to config.json5.