### PR TITLE
docs: Remove v16 upgrade notes

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -135,8 +135,4 @@ Please check out [bitnami redis](https://artifacthub.io/packages/helm/bitnami/re
 
 A major chart version change can indicate that there is an incompatible breaking change needing maual actions.
 
-### To v16
-
-- The `slim` options was removed, the `latest` tag now points to the slim renovate docker image.
-- The `dind` option was removed. The `slim` renovate version uses `binarySource=install`, so no need for complex Docker in Docker setup.
-- The renovate image is now pulled from `ghcr.io/renovatebot/renovate` by default.
+_No recent breaking changes needing manual actions._

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -68,9 +68,6 @@ Please checkout [bitnami redis](https://artifacthub.io/packages/helm/bitnami/red
 
 ## Upgrading
 
-A major chart version change can indicate that there is an incompatible breaking change needing maual actions.
+A major chart version change can indicate that there is an incompatible breaking change needing manual actions.
 
-### To v16
-
-- The `slim` options was removed, the `latest` tag now points to the slim renovate docker image.
-- The `dind` option was removed. The `slim` renovate version uses `binarySource=install`, so no need for complex Docker in Docker setup.
+_No recent breaking changes needing manual actions._


### PR DESCRIPTION
v16 doesn't seem relevant to me anymore, as users upgrading from pre-v16 likely have some other breaking changes to take care of. Starting anew instead of upgrading is probably easier, due to the (great!!!) effort put in to keep this Helm Chart simple.