### PR TITLE
fix: Precede preCommand and postCommand with `set -e`

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -84,10 +84,12 @@ spec:
               args:
                 - |
                 {{- if .Values.cronjob.preCommand }}
+                  set -e
                   {{- .Values.cronjob.preCommand | nindent 18 }}
                 {{- end }}
                   renovate
                 {{- if .Values.cronjob.postCommand }}
+                  set -e
                   {{- .Values.cronjob.postCommand | nindent 18 }}
                 {{- end }}
               {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -83,13 +83,12 @@ spec:
               command: ["/bin/bash", "-c"]
               args:
                 - |
+                  set -e;
                 {{- if .Values.cronjob.preCommand }}
-                  set -e
                   {{- .Values.cronjob.preCommand | nindent 18 }}
                 {{- end }}
                   renovate
                 {{- if .Values.cronjob.postCommand }}
-                  set -e
                   {{- .Values.cronjob.postCommand | nindent 18 }}
                 {{- end }}
               {{- end }}


### PR DESCRIPTION
The templated `preCommand` and `postCommand` values should be preceded with `set -e`, so that the Renovate Kubernetes CronJob fails directly on every non-zero exit code.