### PR TITLE
feat: Add cronjob completions and parallelism options

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -43,12 +43,15 @@ The following table lists the configurable parameters of the chart and the defau
 | apiVersionOverrides.cronjob | string | `""` | String to override apiVersion of cronjob rendered by this helm chart |
 | cronjob.activeDeadlineSeconds | string | `""` | Deadline for the job to finish |
 | cronjob.annotations | object | `{}` | Annotations to set on the cronjob |
+| cronjob.completions | string | `""` | Number of successful completions before the job is considered complete |
+| cronjob.completionMode | string | `""` | Set to `Indexed` the Pods of a Job get an associated completion index from 0 to x |
 | cronjob.concurrencyPolicy | string | `""` | "Allow" to allow concurrent runs, "Forbid" to skip new runs if a previous run is still running or "Replace" to replace the previous run |
 | cronjob.failedJobsHistoryLimit | string | `""` | Amount of failed jobs to keep in history |
 | cronjob.initContainers | list | `[]` | Additional initContainers that can be executed before renovate |
 | cronjob.jobBackoffLimit | string | `""` | Number of times to retry an errored job before considering it as being failed |
 | cronjob.jobRestartPolicy | string | `"Never"` | Set to Never to restart the job when the pod fails or to OnFailure to restart when a container fails |
 | cronjob.labels | object | `{}` | Labels to set on the cronjob |
+| cronjob.parallelism | string | `""` | Number of pods to run in parallel |
 | cronjob.preCommand | string | `""` | Prepend shell commands before renovate runs |
 | cronjob.postCommand | string | `""` | Append shell commands after renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` | Schedules the job to run using cron notation |

--- a/charts/renovate/ci/ci-with-parallelism.yaml
+++ b/charts/renovate/ci/ci-with-parallelism.yaml
@@ -1,0 +1,33 @@
+imagePullSecrets:
+  - name: myregistrykey
+cronjob:
+  completions: 1
+  completionMode: "Indexed"
+  parallelism: 1
+envFrom:
+  - configMapRef:
+      name: my-config
+secrets:
+  my-secret-1: |
+    123
+  my-secret-2: |
+    456
+ssh_config:
+  enabled: true
+  config: |
+    Host *
+      ForwardAgent yes
+renovate:
+  config: |
+    {
+      "platform": "gitlab",
+      "endpoint": "https://gitlab.example.com/api/v4",
+      "token": "your-gitlab-renovate-user-token",
+      "autodiscover": "false",
+      "dryRun": true,
+      "printConfig": true,
+      "logLevel": "debug",
+      "repositories": ["username/repo", "orgname/repo"]
+    }
+
+

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -30,15 +30,6 @@ spec:
   {{- with .Values.cronjob.concurrencyPolicy }}
   concurrencyPolicy: {{ . }}
   {{- end }}
-  {{- with .Values.cronjob.completions }}
-  completions: {{ . }}
-  {{- end }}
-  {{- with .Values.cronjob.completionMode }}
-  completionMode: {{ . }}
-  {{- end }}
-  {{- with .Values.cronjob.parallelism}}
-  parallelism: {{ . }}
-  {{- end }}
   {{- with .Values.cronjob.failedJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ . }}
   {{- end }}
@@ -53,6 +44,15 @@ spec:
       labels:
         {{- include "renovate.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.cronjob.completions }}
+      completions: {{ . }}
+      {{- end }}
+      {{- with .Values.cronjob.completionMode }}
+      completionMode: {{ . }}
+      {{- end }}
+      {{- with .Values.cronjob.parallelism}}
+      parallelism: {{ . }}
+      {{- end }}
       {{- if .Values.cronjob.ttlSecondsAfterFinished }}
       ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished }}
       {{- end }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -30,6 +30,15 @@ spec:
   {{- with .Values.cronjob.concurrencyPolicy }}
   concurrencyPolicy: {{ . }}
   {{- end }}
+  {{- with .Values.cronjob.completions }}
+  completions: {{ . }}
+  {{- end }}
+  {{- with .Values.cronjob.completionMode }}
+  completionMode: {{ . }}
+  {{- end }}
+  {{- with .Values.cronjob.parallelism}}
+  parallelism: {{ . }}
+  {{- end }}
   {{- with .Values.cronjob.failedJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ . }}
   {{- end }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -20,6 +20,10 @@ cronjob:
   labels: {}
   # -- "Allow" to allow concurrent runs, "Forbid" to skip new runs if a previous run is still running or "Replace" to replace the previous run
   concurrencyPolicy: ''
+  # -- "Number of successful completions is reached to mark the job as complete"
+  completions: ''
+  # -- "Where the jobs should be NonIndexed or Indexed"
+  completionMode: ''
   # -- Amount of failed jobs to keep in history
   failedJobsHistoryLimit: ''
   # -- Amount of completed jobs to keep in history
@@ -39,7 +43,8 @@ cronjob:
   # initContainers:
   # - name: INIT_CONTAINER_NAME
   #   image: INIT_CONTAINER_IMAGE
-
+  # -- Number of pods to run in parallel
+  parallelism: ''
   # -- Prepend shell commands before renovate runs
   preCommand: ''
   # preCommand: |


### PR DESCRIPTION
Introduce new configurable options for defining the number of successful completions needed before marking a job complete and specifying the number of pods to run in parallel. This change enhances flexibility in managing cronjobs efficiently.