### PR TITLE
feat(chart): Enable binding the cache PVC to exiting volumes

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -89,10 +89,11 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See README for how to use this value |
 | renovate.configIsSecret | bool | `false` | Use this to create the renovate-config as a secret instead of a configmap |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
-| renovate.persistence | object | `{"cache":{"enabled":false,"storageClass":"","storageSize":"512Mi"}}` | Options related to persistence |
+| renovate.persistence | object | `{"cache":{"enabled":false,"storageClass":"","storageSize":"512Mi","volumeName":""}}` | Options related to persistence |
 | renovate.persistence.cache.enabled | bool | `false` | Allow the cache to persist between runs |
 | renovate.persistence.cache.storageClass | string | `""` | Storage class of the cache PVC |
 | renovate.persistence.cache.storageSize | string | `"512Mi"` | Storage size of the cache PVC |
+| renovate.persistence.cache.volumeName | string | `""` | Existing volume, enables binding the pvc to an existing volume |
 | renovate.securityContext | object | `{}` | Renovate Container-level security-context |
 | resources | object | `{}` | Specify resource limits and requests for the renovate container |
 | secrets | object | `{}` | Environment variables that should be referenced from a k8s secret, cannot be used when existingSecret is set |

--- a/charts/renovate/templates/pvc.yaml
+++ b/charts/renovate/templates/pvc.yaml
@@ -7,6 +7,9 @@ spec:
   {{- if .Values.renovate.persistence.cache.storageClass }}
   storageClassName: {{ .Values.renovate.persistence.cache.storageClass }}
   {{- end }}
+  {{- if .Values.renovate.persistence.cache.volumeName }}
+  volumeName: {{ .Values.renovate.persistence.cache.volumeName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -111,6 +111,8 @@ renovate:
       storageClass: ""
       # -- Storage size of the cache PVC
       storageSize: "512Mi"
+      # -- Existing volume, enables binding the pvc to an existing volume
+      volumeName: ""
 
 ssh_config:
   # -- Whether to enable the use and creation of a secret containing .ssh files


### PR DESCRIPTION
In order to support statically provisioned volumes, we add the option to render volumeName in the pvc's spec if volumeName is provided.

Defined here: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimspec-v1-core