### PR TITLE
Fix doc generation

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
-
-mkdir ./.bin
-export PATH="./.bin:$PATH"
-
-set -euxo pipefail
+set -e pipefail
 
 # renovate: datasource=github-releases depName=helm-docs packageName=norwoodj/helm-docs
-HELM_DOCS_VERSION=1.13.1
+HELM_DOCS_VERSION="v1.13.1"
 
-# install helm-docs
-curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz
-tar -C .bin/ -xf /tmp/helm-docs.tar.gz helm-docs
+go run github.com/norwoodj/helm-docs/cmd/helm-docs@"${HELM_DOCS_VERSION}"
 
 # validate docs
-helm-docs
 git diff --exit-code

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -38,36 +38,36 @@ The following table lists the configurable parameters of the chart and the defau
 ## Values
 
 | Key | Type | Default | Description |
-|-----|------|-------|-------------|
+|-----|------|---------|-------------|
 | affinity | object | `{}` | Configure the pod(Anti)Affinity and/or node(Anti)Affinity |
 | apiVersionOverrides.cronjob | string | `""` | String to override apiVersion of cronjob rendered by this helm chart |
 | cronjob.activeDeadlineSeconds | string | `""` | Deadline for the job to finish |
 | cronjob.annotations | object | `{}` | Annotations to set on the cronjob |
-| cronjob.completions | string | `""` | Number of successful completions before the job is considered complete |
-| cronjob.completionMode | string | `""` | Set to `Indexed` the Pods of a Job get an associated completion index from 0 to x |
+| cronjob.completionMode | string | `""` | "Where the jobs should be NonIndexed or Indexed" |
+| cronjob.completions | string | `""` | "Number of successful completions is reached to mark the job as complete" |
 | cronjob.concurrencyPolicy | string | `""` | "Allow" to allow concurrent runs, "Forbid" to skip new runs if a previous run is still running or "Replace" to replace the previous run |
 | cronjob.failedJobsHistoryLimit | string | `""` | Amount of failed jobs to keep in history |
 | cronjob.initContainers | list | `[]` | Additional initContainers that can be executed before renovate |
-| cronjob.jobBackoffLimit | string | `""` | Number of times to retry an errored job before considering it as being failed |
+| cronjob.jobBackoffLimit | string | `""` | Number of times to retry running the pod before considering the job as being failed |
 | cronjob.jobRestartPolicy | string | `"Never"` | Set to Never to restart the job when the pod fails or to OnFailure to restart when a container fails |
 | cronjob.labels | object | `{}` | Labels to set on the cronjob |
 | cronjob.parallelism | string | `""` | Number of pods to run in parallel |
-| cronjob.preCommand | string | `""` | Prepend shell commands before renovate runs |
 | cronjob.postCommand | string | `""` | Append shell commands after renovate runs |
+| cronjob.preCommand | string | `""` | Prepend shell commands before renovate runs |
 | cronjob.schedule | string | `"0 1 * * *"` | Schedules the job to run using cron notation |
 | cronjob.startingDeadlineSeconds | string | `""` | Deadline to start the job, skips execution if job misses it's configured deadline |
 | cronjob.successfulJobsHistoryLimit | string | `""` | Amount of completed jobs to keep in history |
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
-| cronJob.timeZone | string | `""` | You can specify a time zone for a CronJob by setting timeZone to the name of a valid time zone. (starting with k8s 1.27) <https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones> |
-| cronjob.ttlSecondsAfterFinished | string | `"""` | Time to keep the job after it finished before automatically deleting it |
+| cronjob.timeZone | string | `""` | You can specify a time zone for a CronJob by setting timeZone to the name of a valid time zone. (starting with k8s 1.27) <https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones> |
+| cronjob.ttlSecondsAfterFinished | string | `""` | Time to keep the job after it finished before automatically deleting it |
 | env | object | `{}` | Environment variables to set on the renovate container |
 | envFrom | list | `[]` | Environment variables to add from existing secrets/configmaps. Uses the keys as variable name |
 | envList | list | `[]` | Additional env. Helpful too if you want to use anything other than a `value` source. |
 | existingSecret | string | `""` | k8s secret to reference environment variables from. Overrides secrets if set |
 | extraConfigmaps | list | `[]` | Additional configmaps. A generated configMap name is: "renovate.fullname" + "extra" + name(below) e.g. renovate-netrc-config |
+| extraContainers | list | `[]` | Additional containers to the pod |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to the container |
 | extraVolumes | list | `[]` | Additional volumes to the pod |
-| extraContainers | list | `[]` | Additional containers to the pod |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
 | global.commonLabels | object | `{}` | Additional labels to be set on all renovate resources |
 | hostAliases | list | `[]` | Override hostname resolution |
@@ -89,6 +89,7 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See README for how to use this value |
 | renovate.configIsSecret | bool | `false` | Use this to create the renovate-config as a secret instead of a configmap |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
+| renovate.persistence | object | `{"cache":{"enabled":false,"storageClass":"","storageSize":"512Mi"}}` | Options related to persistence |
 | renovate.persistence.cache.enabled | bool | `false` | Allow the cache to persist between runs |
 | renovate.persistence.cache.storageClass | string | `""` | Storage class of the cache PVC |
 | renovate.persistence.cache.storageSize | string | `"512Mi"` | Storage size of the cache PVC |
@@ -98,7 +99,7 @@ The following table lists the configurable parameters of the chart and the defau
 | securityContext | object | `{}` | Pod-level security-context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `""` | The name of the service account to use |
+| serviceAccount.name | string | `""` | The name of the service account to use If not set and create is true, a name is generated using the fullname template |
 | ssh_config.config | string | `""` | Contents of the config file |
 | ssh_config.enabled | bool | `false` | Whether to enable the use and creation of a secret containing .ssh files |
 | ssh_config.existingSecret | string | `""` | Name of the existing secret containing a valid .ssh configuration |
@@ -118,11 +119,11 @@ can't write to the mounted PVC. For the current default user (`ubuntu`), the cor
 ## Renovate config templating
 
 Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
-Allows you to reference values using `"{{ .Values.someValue }}"` in your config
+Allows you to reference values using `"\\{\\{ .Values.someValue \\}\\}"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to
-escape your config entries containing `{{` (i.e. `"key": "{{depName}}"`) in the
-value by wrapping it like: `"key": "{{ "{{depName}}" }}"`.
+escape your config entries containing `\{\{` (i.e. `"key": "\{\{depName\}\}"`) in the
+value by wrapping it like: `"key": "\{\{ "\{\{depName\}\}" \}\}"`.
 
 ## Renovate full image
 
@@ -132,10 +133,10 @@ If you like to use a specific major version, set the `image.tag` to `36-full`.
 
 ## Redis
 
-Please check out [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
+Please checkout [bitnami redis](https://artifacthub.io/packages/helm/bitnami/redis) chart for additional redis configuration.
 
 ## Upgrading
 
-A major chart version change can indicate that there is an incompatible breaking change needing maual actions.
+A major chart version change can indicate that there is an incompatible breaking change needing manual actions.
 
 _No recent breaking changes needing manual actions._

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -119,11 +119,13 @@ can't write to the mounted PVC. For the current default user (`ubuntu`), the cor
 ## Renovate config templating
 
 Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
-Allows you to reference values using `"\\{\\{ .Values.someValue \\}\\}"` in your config
+Allows you to reference values using `"` .Values.someValue `"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to
-escape your config entries containing `\{\{` (i.e. `"key": "\{\{depName\}\}"`) in the
-value by wrapping it like: `"key": "\{\{ "\{\{depName\}\}" \}\}"`.
+escape your config entries containing {{ (i.e. `"key": "{{{depName}}"`) in the
+value by wrapping it like: `"key": "{{ "\{\{depName\}\}" \}\}"`.
+
+}}
 
 ## Renovate full image
 

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -50,11 +50,11 @@ can't write to the mounted PVC. For the current default user (`ubuntu`), the cor
 ## Renovate config templating
 
 Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
-Allows you to reference values using `"{{ .Values.someValue }}"` in your config
+Allows you to reference values using `"\\{\\{ .Values.someValue \\}\\}"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to
-escape your config entries containing `{{` (i.e. `"key": "{{depName}}"`) in the
-value by wrapping it like: `"key": "{{ "{{depName}}" }}"`.
+escape your config entries containing `\{\{` (i.e. `"key": "\{\{depName\}\}"`) in the
+value by wrapping it like: `"key": "\{\{ "\{\{depName\}\}" \}\}"`.
 
 ## Renovate full image
 

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -50,11 +50,13 @@ can't write to the mounted PVC. For the current default user (`ubuntu`), the cor
 ## Renovate config templating
 
 Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.
-Allows you to reference values using `"\\{\\{ .Values.someValue \\}\\}"` in your config
+Allows you to reference values using `"`{{` .Values.someValue `}}`"` in your config
 
 **NOTE**: setting `renovate.configEnableHelmTpl` to true means that you have to
-escape your config entries containing `\{\{` (i.e. `"key": "\{\{depName\}\}"`) in the
-value by wrapping it like: `"key": "\{\{ "\{\{depName\}\}" \}\}"`.
+escape your config entries containing {{ `{{` }} (i.e. `"key": "{{ `{{` }}{depName{{ `}}` }}"`) in the
+value by wrapping it like: `"key": "{{ `{{` }} "{{ `{{` }}depName{{ `}}` }} {{ `}}` }}"`.
+
+{{ `}}` }}
 
 ## Renovate full image
 


### PR DESCRIPTION
Script was failing silently. see #1303 

CHanges:
* make the script fail on exit. (not that it matters, since helm-docs don't fail on error) return code is 0 on failures. :( 
* use go to run the image direclty instead of  downloading a version. Most of the CI images already have it.
* update the template so it's properly escaped.
* run the template (hence all the changes in the readme)