### PR TITLE
feat: add an opinion to use `full` tag

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
 | image.tag | string | `"37.354.0"` | Renovate image tag to pull |
+| image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` | Select the node using labels to specify where the cronjob pod should run on |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -86,7 +86,7 @@ spec:
           {{- end }}
           containers:
             - name: {{ .Chart.Name }}
-              image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.useFull | ternary (printf "%s-full" .Values.image.tag) .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- if or .Values.cronjob.preCommand .Values.cronjob.postCommand}}
               command: ["/bin/bash", "-c"]

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -72,6 +72,8 @@ image:
   tag: 37.354.0
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
+  # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image
+  useFull: false
 
 # -- Secret to use to pull the image from the repository
 imagePullSecrets: {}


### PR DESCRIPTION
The [documentation](https://docs.renovatebot.com/getting-started/running/#the-full-image) points users to the 'full' image. This image is useful when users are behind restrictive firewalls. However, the chart currently requires users to override the tag to use the full image. This prevents users from upgrading the image when the chart upgrades.

This PR provides the ability for users to upgrade the image as and when chart is upgraded while also using the full image