### PR TITLE
feat(override-command): add options to override command and args

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -43,6 +43,8 @@ The following table lists the configurable parameters of the chart and the defau
 | apiVersionOverrides.cronjob | string | `""` | String to override apiVersion of cronjob rendered by this helm chart |
 | cronjob.activeDeadlineSeconds | string | `""` | Deadline for the job to finish |
 | cronjob.annotations | object | `{}` | Annotations to set on the cronjob |
+| cronjob.argsOverride | list | `[]` | Custom arguments to run in the container |
+| cronjob.commandOverride | list | `[]` | Custom command to run in the container |
 | cronjob.completionMode | string | `""` | "Where the jobs should be NonIndexed or Indexed" |
 | cronjob.completions | string | `""` | "Number of successful completions is reached to mark the job as complete" |
 | cronjob.concurrencyPolicy | string | `""` | "Allow" to allow concurrent runs, "Forbid" to skip new runs if a previous run is still running or "Replace" to replace the previous run |

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -88,7 +88,16 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              {{- if or .Values.cronjob.preCommand .Values.cronjob.postCommand}}
+              {{- if or .Values.cronjob.commandOverride .Values.cronjob.argsOverride }}
+              {{- if .Values.cronjob.commandOverride }}
+              command:
+                {{- toYaml .Values.cronjob.commandOverride | nindent 16 }}
+              {{- end }}
+              {{- if .Values.cronjob.argsOverride }}
+              args:
+                {{- toYaml .Values.cronjob.argsOverride | nindent 16 }}
+              {{- end }}
+              {{- else if or .Values.cronjob.preCommand .Values.cronjob.postCommand }}
               command: ["/bin/bash", "-c"]
               args:
                 - |

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -45,6 +45,10 @@ cronjob:
   #   image: INIT_CONTAINER_IMAGE
   # -- Number of pods to run in parallel
   parallelism: ''
+  # -- Custom command to run in the container
+  commandOverride: []
+  # -- Custom arguments to run in the container
+  argsOverride: []
   # -- Prepend shell commands before renovate runs
   preCommand: ''
   # preCommand: |


### PR DESCRIPTION
We are running Renovate on few thousand repositories on a self-hosted Gitlab, and time to time, Gitlab produce a 429 return status code when POST/PUT a merge request, making a Renovate returning a non-zero code.

We don't really mind these fails, as it appears 2 or 3 times per run and renovate run twice a day.
But the `set -e` option let the cronjob as fail for Kubernetes, making it to be re run instantly, spamming the resources, without repeating the error on the same repo/branch.
So I propose to have an option to override the whole command and args part, to be able to override the `set -e` options