### PR TITLE
fix: persistance labels template

### DIFF
--- a/charts/renovate/templates/pvc.yaml
+++ b/charts/renovate/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "renovate.fullname" . }}-cache
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
-  {{- with .Values.persistence.cache.labels }}
+  {{- with .Values.renovate.persistence.cache.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
Fix for https://github.com/renovatebot/helm-charts/pull/1593

The value field reference is non-existing, leading to:

```
Error: template: renovate/charts/renovate/templates/pvc.yaml:8:18: executing "renovate/charts/renovate/templates/pvc.yaml" at <.Values.persistence.cache.labels>: nil pointer evaluating interface {}.cache
```