### PR TITLE
fix: Adds missing indentation for securityContext

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -203,7 +203,7 @@ spec:
             {{- with .Values.securityContext }}
             {{ $securityDict := omit . "fsGroup" }}
             {{- if not (empty $securityDict) }}
-              {{- toYaml $securityDict }}
+              {{- toYaml $securityDict | nindent 12 }}
             {{ end }}
             {{ end }}
         {{- else }}


### PR DESCRIPTION
If a `securityContext` is defined in the chart values and `persistence.cache` is enabled, the indentation of the `securityContext` was not correct.