### PR TITLE
fix: allow fsGroup to be set to null instead of defaulting it to 1000

### DIFF
--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -199,7 +199,7 @@ spec:
         {{- end }}
         {{- if .Values.renovate.persistence.cache.enabled }}
           securityContext:
-            fsGroup: {{ .Values.securityContext.fsGroup | default 1000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default (hasKey .Values.securityContext "fsGroup" | ternary "null" 1000) }}
             {{- with .Values.securityContext }}
             {{ $securityDict := omit . "fsGroup" }}
             {{- if not (empty $securityDict) }}


### PR DESCRIPTION
#### Problem:
Currently, when caching is enabled, the pod's `securityContext` defaults the `fsGroup` to `1000`, even if it is explicitly set to `null`. This behavior can conflict with environments like OpenShift, which uses **Security Context Constraints (SCCs)** to automatically manage certain security context fields (e.g., `runAsUser`, `fsGroup`, `seLinuxOptions`).

In OpenShift's **restricted SCC**, these fields are enforced to ensure pods run with minimal privileges, and manually setting them may cause issues or break security compliance. In such cases, the `securityContext` should not be explicitly set or should allow fields like `fsGroup` to be left as `null`.

#### Solution:
This change ensures that the `fsGroup` value can be explicitly set to `null` within the `securityContext` without defaulting to `1000`. The new behavior will be as follows:

```yaml
securityContext:
  fsGroup: ~
