### PR TITLE
docs: recommend redis when users want to use a cache for renovate

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/containerbase/devcontainer:13.2.0
+FROM ghcr.io/containerbase/devcontainer:13.2.1
 
 USER root
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/containerbase/devcontainer:13.2.1
+FROM ghcr.io/containerbase/devcontainer:13.2.2
 
 USER root
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/containerbase/devcontainer:13.1.0
+FROM ghcr.io/containerbase/devcontainer:13.2.0
 
 USER root
 

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.57.0'
+appVersion: '39.57.1'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.57.0'
+version: '39.57.1'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.57.0
-      image: ghcr.io/renovatebot/renovate:39.57.0
+    - name: ghcr.io/renovatebot/renovate:39.57.1
+      image: ghcr.io/renovatebot/renovate:39.57.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.57.1'
+appVersion: '39.57.2'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.57.1'
+version: '39.57.2'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.57.1
-      image: ghcr.io/renovatebot/renovate:39.57.1
+    - name: ghcr.io/renovatebot/renovate:39.57.2
+      image: ghcr.io/renovatebot/renovate:39.57.2
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.58.0'
+appVersion: '39.58.1'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.58.0'
+version: '39.58.1'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.58.0
-      image: ghcr.io/renovatebot/renovate:39.58.0
+    - name: ghcr.io/renovatebot/renovate:39.58.1
+      image: ghcr.io/renovatebot/renovate:39.58.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.57.4'
+appVersion: '39.58.0'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.57.4'
+version: '39.58.0'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.57.4
-      image: ghcr.io/renovatebot/renovate:39.57.4
+    - name: ghcr.io/renovatebot/renovate:39.58.0
+      image: ghcr.io/renovatebot/renovate:39.58.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.54.0'
+appVersion: '39.55.0'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.54.0'
+version: '39.55.0'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.54.0
-      image: ghcr.io/renovatebot/renovate:39.54.0
+    - name: ghcr.io/renovatebot/renovate:39.55.0
+      image: ghcr.io/renovatebot/renovate:39.55.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.55.0'
+appVersion: '39.56.2'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.55.0'
+version: '39.56.2'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.55.0
-      image: ghcr.io/renovatebot/renovate:39.55.0
+    - name: ghcr.io/renovatebot/renovate:39.56.2
+      image: ghcr.io/renovatebot/renovate:39.56.2
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.56.4'
+appVersion: '39.57.0'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.56.4'
+version: '39.57.0'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.56.4
-      image: ghcr.io/renovatebot/renovate:39.56.4
+    - name: ghcr.io/renovatebot/renovate:39.57.0
+      image: ghcr.io/renovatebot/renovate:39.57.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.52.0'
+appVersion: '39.54.0'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.52.0'
+version: '39.54.0'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.52.0
-      image: ghcr.io/renovatebot/renovate:39.52.0
+    - name: ghcr.io/renovatebot/renovate:39.54.0
+      image: ghcr.io/renovatebot/renovate:39.54.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.57.2'
+appVersion: '39.57.4'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.57.2'
+version: '39.57.4'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.57.2
-      image: ghcr.io/renovatebot/renovate:39.57.2
+    - name: ghcr.io/renovatebot/renovate:39.57.4
+      image: ghcr.io/renovatebot/renovate:39.57.4
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '39.56.2'
+appVersion: '39.56.4'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.56.2'
+version: '39.56.4'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:
@@ -24,8 +24,8 @@ maintainers:
 annotations:
   artifacthub.io/license: AGPL-3.0-only
   artifacthub.io/images: |
-    - name: ghcr.io/renovatebot/renovate:39.56.2
-      image: ghcr.io/renovatebot/renovate:39.56.2
+    - name: ghcr.io/renovatebot/renovate:39.56.4
+      image: ghcr.io/renovatebot/renovate:39.56.4
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.58.0](https://img.shields.io/badge/Version-39.58.0-informational?style=flat-square) ![AppVersion: 39.58.0](https://img.shields.io/badge/AppVersion-39.58.0-informational?style=flat-square)
+![Version: 39.58.1](https://img.shields.io/badge/Version-39.58.1-informational?style=flat-square) ![AppVersion: 39.58.1](https://img.shields.io/badge/AppVersion-39.58.1-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.58.0"` | Renovate image tag to pull |
+| image.tag | string | `"39.58.1"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.52.0](https://img.shields.io/badge/Version-39.52.0-informational?style=flat-square) ![AppVersion: 39.52.0](https://img.shields.io/badge/AppVersion-39.52.0-informational?style=flat-square)
+![Version: 39.54.0](https://img.shields.io/badge/Version-39.54.0-informational?style=flat-square) ![AppVersion: 39.54.0](https://img.shields.io/badge/AppVersion-39.54.0-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.52.0"` | Renovate image tag to pull |
+| image.tag | string | `"39.54.0"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.54.0](https://img.shields.io/badge/Version-39.54.0-informational?style=flat-square) ![AppVersion: 39.54.0](https://img.shields.io/badge/AppVersion-39.54.0-informational?style=flat-square)
+![Version: 39.55.0](https://img.shields.io/badge/Version-39.55.0-informational?style=flat-square) ![AppVersion: 39.55.0](https://img.shields.io/badge/AppVersion-39.55.0-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.54.0"` | Renovate image tag to pull |
+| image.tag | string | `"39.55.0"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.57.1](https://img.shields.io/badge/Version-39.57.1-informational?style=flat-square) ![AppVersion: 39.57.1](https://img.shields.io/badge/AppVersion-39.57.1-informational?style=flat-square)
+![Version: 39.57.2](https://img.shields.io/badge/Version-39.57.2-informational?style=flat-square) ![AppVersion: 39.57.2](https://img.shields.io/badge/AppVersion-39.57.2-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.57.1"` | Renovate image tag to pull |
+| image.tag | string | `"39.57.2"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.57.2](https://img.shields.io/badge/Version-39.57.2-informational?style=flat-square) ![AppVersion: 39.57.2](https://img.shields.io/badge/AppVersion-39.57.2-informational?style=flat-square)
+![Version: 39.57.4](https://img.shields.io/badge/Version-39.57.4-informational?style=flat-square) ![AppVersion: 39.57.4](https://img.shields.io/badge/AppVersion-39.57.4-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.57.2"` | Renovate image tag to pull |
+| image.tag | string | `"39.57.4"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.57.0](https://img.shields.io/badge/Version-39.57.0-informational?style=flat-square) ![AppVersion: 39.57.0](https://img.shields.io/badge/AppVersion-39.57.0-informational?style=flat-square)
+![Version: 39.57.1](https://img.shields.io/badge/Version-39.57.1-informational?style=flat-square) ![AppVersion: 39.57.1](https://img.shields.io/badge/AppVersion-39.57.1-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.57.0"` | Renovate image tag to pull |
+| image.tag | string | `"39.57.1"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.56.2](https://img.shields.io/badge/Version-39.56.2-informational?style=flat-square) ![AppVersion: 39.56.2](https://img.shields.io/badge/AppVersion-39.56.2-informational?style=flat-square)
+![Version: 39.56.4](https://img.shields.io/badge/Version-39.56.4-informational?style=flat-square) ![AppVersion: 39.56.4](https://img.shields.io/badge/AppVersion-39.56.4-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.56.2"` | Renovate image tag to pull |
+| image.tag | string | `"39.56.4"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.57.4](https://img.shields.io/badge/Version-39.57.4-informational?style=flat-square) ![AppVersion: 39.57.4](https://img.shields.io/badge/AppVersion-39.57.4-informational?style=flat-square)
+![Version: 39.58.0](https://img.shields.io/badge/Version-39.58.0-informational?style=flat-square) ![AppVersion: 39.58.0](https://img.shields.io/badge/AppVersion-39.58.0-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.57.4"` | Renovate image tag to pull |
+| image.tag | string | `"39.58.0"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.56.4](https://img.shields.io/badge/Version-39.56.4-informational?style=flat-square) ![AppVersion: 39.56.4](https://img.shields.io/badge/AppVersion-39.56.4-informational?style=flat-square)
+![Version: 39.57.0](https://img.shields.io/badge/Version-39.57.0-informational?style=flat-square) ![AppVersion: 39.57.0](https://img.shields.io/badge/AppVersion-39.57.0-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.56.4"` | Renovate image tag to pull |
+| image.tag | string | `"39.57.0"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.55.0](https://img.shields.io/badge/Version-39.55.0-informational?style=flat-square) ![AppVersion: 39.55.0](https://img.shields.io/badge/AppVersion-39.55.0-informational?style=flat-square)
+![Version: 39.56.2](https://img.shields.io/badge/Version-39.56.2-informational?style=flat-square) ![AppVersion: 39.56.2](https://img.shields.io/badge/AppVersion-39.56.2-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.pullPolicy | string | `"IfNotPresent"` | "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images |
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
-| image.tag | string | `"39.55.0"` | Renovate image tag to pull |
+| image.tag | string | `"39.56.2"` | Renovate image tag to pull |
 | image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -44,6 +44,8 @@ To speed up execution time of jobs it could be useful to enable persistent cachi
 can make use of the cache that have been build up in previous runs. Set `renovate.persistence.cache.enabled` to true
 to enable this. If necessary, the storageClass can be configured and the storageSize can be set to the preferred value.
 
+**HINT**: It is highly recommended to use the redis subchart or SQLite for caching, instead of disk caching.
+Take a look at https://github.com/renovatebot/renovate/discussions/30525 for more information.
 
 ## Renovate config templating
 

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.54.0
+  tag: 39.55.0
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.56.4
+  tag: 39.57.0
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -116,6 +116,9 @@ renovate:
   # -- Renovate Container-level security-context
   securityContext: {}
 
+  # Instead of a file system cache, it is highly recommended to use the redis subchart.
+  # Alternatively, SQLite is also a good choice.
+  # Take a look at https://github.com/renovatebot/renovate/discussions/30525 for more information.
   # -- Options related to persistence
   persistence:
     cache:

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.55.0
+  tag: 39.56.2
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.57.0
+  tag: 39.57.1
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.57.4
+  tag: 39.58.0
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.57.2
+  tag: 39.57.4
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.56.2
+  tag: 39.56.4
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.57.1
+  tag: 39.57.2
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.52.0
+  tag: 39.54.0
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -81,7 +81,7 @@ image:
   # -- Image name to pull
   repository: renovatebot/renovate
   # -- Renovate image tag to pull
-  tag: 39.58.0
+  tag: 39.58.1
   # -- "IfNotPresent" to pull the image if no image with the specified tag exists on the node, "Always" to always pull the image or "Never" to try and use pre-pulled images
   pullPolicy: IfNotPresent
   # -- Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image


### PR DESCRIPTION
The disk cache is very likely to pile up quickly. This will
prevent the Job to be executed once the PersistentVolume is full.
More information can be found here:
https://github.com/renovatebot/renovate/discussions/30525

Signed-off-by: Tim Beermann <tibeer@outlook.de>
