### PR TITLE
docs: recommend redis when users want to use a cache for renovate

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -121,6 +121,9 @@ To speed up execution time of jobs it could be useful to enable persistent cachi
 can make use of the cache that have been build up in previous runs. Set `renovate.persistence.cache.enabled` to true
 to enable this. If necessary, the storageClass can be configured and the storageSize can be set to the preferred value.
 
+**HINT**: It is highly recommended to use the redis subchart or SQLite for caching, instead of disk caching.
+Take a look at https://github.com/renovatebot/renovate/discussions/30525 for more information.
+
 ## Renovate config templating
 
 Enable `renovate.configEnableHelmTpl` to use helm templates for generated renovate `config.json`.

--- a/charts/renovate/README.md.gotmpl
+++ b/charts/renovate/README.md.gotmpl
@@ -44,6 +44,8 @@ To speed up execution time of jobs it could be useful to enable persistent cachi
 can make use of the cache that have been build up in previous runs. Set `renovate.persistence.cache.enabled` to true
 to enable this. If necessary, the storageClass can be configured and the storageSize can be set to the preferred value.
 
+**HINT**: It is highly recommended to use the redis subchart or SQLite for caching, instead of disk caching.
+Take a look at https://github.com/renovatebot/renovate/discussions/30525 for more information.
 
 ## Renovate config templating
 

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -116,6 +116,9 @@ renovate:
   # -- Renovate Container-level security-context
   securityContext: {}
 
+  # Instead of a file system cache, it is highly recommended to use the redis subchart.
+  # Alternatively, SQLite is also a good choice.
+  # Take a look at https://github.com/renovatebot/renovate/discussions/30525 for more information.
   # -- Options related to persistence
   persistence:
     cache:


### PR DESCRIPTION
The disk cache is very likely to pile up quickly. This will
prevent the Job to be executed once the PersistentVolume is full.
More information can be found here:
renovatebot/renovate#30525

Signed-off-by: Tim Beermann <tibeer@outlook.de>
