### PR TITLE
feat(helm): Add secret annotations

### DIFF
--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: '39.173.1'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.173.1'
+version: '39.173.2'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:

--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: '39.173.1'
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '39.173.2'
+version: '39.173.1'
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.173.1](https://img.shields.io/badge/Version-39.173.1-informational?style=flat-square) ![AppVersion: 39.173.1](https://img.shields.io/badge/AppVersion-39.173.1-informational?style=flat-square)
+![Version: 39.173.2](https://img.shields.io/badge/Version-39.173.2-informational?style=flat-square) ![AppVersion: 39.173.1](https://img.shields.io/badge/AppVersion-39.173.1-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.persistence.cache.volumeName | string | `""` | Existing volume, enables binding the pvc to an existing volume |
 | renovate.securityContext | object | `{}` | Renovate Container-level security-context |
 | resources | object | `{}` | Specify resource limits and requests for the renovate container |
+| secretAnnotations | object | `{}` | Annotations to add to secret |
 | secrets | object | `{}` | Environment variables that should be referenced from a k8s secret, cannot be used when existingSecret is set |
 | securityContext | object | `{}` | Pod-level security-context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 39.173.2](https://img.shields.io/badge/Version-39.173.2-informational?style=flat-square) ![AppVersion: 39.173.1](https://img.shields.io/badge/AppVersion-39.173.1-informational?style=flat-square)
+![Version: 39.173.1](https://img.shields.io/badge/Version-39.173.1-informational?style=flat-square) ![AppVersion: 39.173.1](https://img.shields.io/badge/AppVersion-39.173.1-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 

--- a/charts/renovate/templates/config.yaml
+++ b/charts/renovate/templates/config.yaml
@@ -15,11 +15,9 @@ metadata:
   name: {{ template "renovate.fullname" . }}-config
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
-  {{- if .Values.renovate.configIsSecret }}
   {{- with .Values.secretAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- end }}
   {{- end }}
 {{- if .Values.renovate.configIsSecret }}
 stringData:

--- a/charts/renovate/templates/config.yaml
+++ b/charts/renovate/templates/config.yaml
@@ -15,6 +15,12 @@ metadata:
   name: {{ template "renovate.fullname" . }}-config
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
+  {{- if .Values.renovate.configIsSecret }}
+  {{- with .Values.secretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 {{- if .Values.renovate.configIsSecret }}
 stringData:
 {{- else }}

--- a/charts/renovate/templates/secret.yaml
+++ b/charts/renovate/templates/secret.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ template "renovate.fullname" . }}-secret
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
+  {{- with .Values.secretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- range $k, $v := index .Values.secrets }}

--- a/charts/renovate/templates/ssh-secret.yaml
+++ b/charts/renovate/templates/ssh-secret.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ template "renovate.sshSecretName" . }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
+  {{- with .Values.secretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
 {{- if .Values.ssh_config.config }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ''
 # -- Override the fully qualified app name
 fullnameOverride: ''
+# -- Annotations to add to secret
+secretAnnotations: {}
 
 cronjob:
   # -- Schedules the job to run using cron notation


### PR DESCRIPTION
Allow adding annotations to secret resources.

E.g.: A Kubernetes mutating webhook that makes direct secret injection using annotations - https://bank-vaults.dev/docs/mutating-webhook/annotations/