### PR TITLE
feat: Add release namespace to resources

### DIFF
--- a/charts/renovate/templates/config.yaml
+++ b/charts/renovate/templates/config.yaml
@@ -13,6 +13,7 @@ kind: ConfigMap
 {{- end }}
 metadata:
   name: {{ template "renovate.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -6,6 +6,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "renovate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.cronjob.labels }}

--- a/charts/renovate/templates/extra-configmap.yaml
+++ b/charts/renovate/templates/extra-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "renovate.fullname" $ }}-extra-{{ .name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "renovate.labels" $ | nindent 4 }}
 data:

--- a/charts/renovate/templates/pvc.yaml
+++ b/charts/renovate/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "renovate.fullname" . }}-cache
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.renovate.persistence.cache.labels }}

--- a/charts/renovate/templates/secret.yaml
+++ b/charts/renovate/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "renovate.fullname" . }}-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}

--- a/charts/renovate/templates/serviceaccount.yaml
+++ b/charts/renovate/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "renovate.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/renovate/templates/ssh-secret.yaml
+++ b/charts/renovate/templates/ssh-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "renovate.sshSecretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}


### PR DESCRIPTION
It's common for helm charts to render the manifests with a namespace
matching the helm release namespace.
