### PR TITLE
fix: nil pointer error in extra-configmap.yaml

### DIFF
--- a/charts/renovate/templates/extra-configmap.yaml
+++ b/charts/renovate/templates/extra-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "renovate.fullname" $ }}-extra-{{ .name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "renovate.labels" $ | nindent 4 }}
 data:


### PR DESCRIPTION
Fix error
```
 Error: template: renovate/templates/extra-configmap.yaml:7:24: executing "renovate/templates/extra-configmap.yaml" at <.Release.Namespace>: nil pointer evaluating interface {}.Namespace Use --debug flag to render out invalid YAML
 ```
 
 Related to
 - https://github.com/renovatebot/helm-charts/pull/2410