### PR TITLE
fix: omit namespace if default

### DIFF
--- a/charts/renovate/templates/config.yaml
+++ b/charts/renovate/templates/config.yaml
@@ -13,7 +13,9 @@ kind: ConfigMap
 {{- end }}
 metadata:
   name: {{ template "renovate.fullname" . }}-config
+  {{- if ne .Release.Namespace "default" }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -6,7 +6,9 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "renovate.fullname" . }}
+  {{- if ne .Release.Namespace "default" }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.cronjob.labels }}

--- a/charts/renovate/templates/extra-configmap.yaml
+++ b/charts/renovate/templates/extra-configmap.yaml
@@ -4,7 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "renovate.fullname" $ }}-extra-{{ .name }}
+  {{- if ne $.Release.Namespace "default" }}
   namespace: {{ $.Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "renovate.labels" $ | nindent 4 }}
 data:

--- a/charts/renovate/templates/pvc.yaml
+++ b/charts/renovate/templates/pvc.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "renovate.fullname" . }}-cache
+  {{- if ne .Release.Namespace "default" }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.renovate.persistence.cache.labels }}

--- a/charts/renovate/templates/secret.yaml
+++ b/charts/renovate/templates/secret.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "renovate.fullname" . }}-secret
+  {{- if ne .Release.Namespace "default" }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}

--- a/charts/renovate/templates/serviceaccount.yaml
+++ b/charts/renovate/templates/serviceaccount.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "renovate.serviceAccountName" . }}
+  {{- if ne .Release.Namespace "default" }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/renovate/templates/ssh-secret.yaml
+++ b/charts/renovate/templates/ssh-secret.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "renovate.sshSecretName" . }}
+  {{- if ne .Release.Namespace "default" }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "renovate.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}


### PR DESCRIPTION
If release namespace is the default namespace omit rendering it for the resources.
This restores breaking backward compatibility mentioned by @mkurde:
<https://github.com/renovatebot/helm-charts/pull/2410#issuecomment-2865622106>
