### PR TITLE
fix: Allow to use json5 config file without warning

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -94,6 +94,7 @@ The following table lists the configurable parameters of the chart and the defau
 | renovate.config | string | `""` | Inline global renovate config.json |
 | renovate.configEnableHelmTpl | bool | `false` | Use the Helm tpl function on your configuration. See README for how to use this value |
 | renovate.configIsJavaScript | bool | `false` | Use this to create a config.js instead of a config.json |
+| renovate.configIsJson5 | bool | `false` | Use this to create a config.json5 instead of a config.json |
 | renovate.configIsSecret | bool | `false` | Use this to create the renovate-config as a secret instead of a configmap |
 | renovate.existingConfigFile | string | `""` | Custom exiting global renovate config |
 | renovate.persistence | object | `{"cache":{"enabled":false,"labels":{},"storageClass":"","storageSize":"512Mi","volumeName":""}}` | Options related to persistence |

--- a/charts/renovate/templates/config.yaml
+++ b/charts/renovate/templates/config.yaml
@@ -1,6 +1,8 @@
 {{- $configFileName := "config.json" }}
 {{- if .Values.renovate.configIsJavaScript }}
   {{- $configFileName = "config.js" }}
+{{- else if .Values.renovate.configIsJson5 }}
+  {{- $configFileName = "config.json5" }}
 {{- end }}
 
 {{- if not .Values.renovate.existingConfigFile }}

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -1,6 +1,8 @@
 {{- $configFileName := "config.json" }}
 {{- if .Values.renovate.configIsJavaScript }}
   {{- $configFileName = "config.js" }}
+{{- else if .Values.renovate.configIsJson5 }}
+  {{- $configFileName = "config.json5" }}
 {{- end }}
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -118,6 +118,9 @@ renovate:
   # -- Use this to create a config.js instead of a config.json
   configIsJavaScript: false
 
+  # -- Use this to create a config.json5 instead of a config.json
+  configIsJson5: false
+
   # -- Renovate Container-level security-context
   securityContext: {}
 


### PR DESCRIPTION
When using a json5 file formatting for the `renovate.config` key the following warning is printed on the beginning of each renovate run.

```
WARN: File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.
```

This PR adds a new `configIsJson5` option that changes the config file extension to `.json5` to prevent this warning. It's similar to the already existing `configIsJavaScript` option.