### PR TITLE
feat: split chart version from renovate version

### DIFF
--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '41.46.3'
+appVersion: 41.46.3
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: '41.46.3'
+version: 42.0.0
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 41.46.3](https://img.shields.io/badge/Version-41.46.3-informational?style=flat-square) ![AppVersion: 41.46.3](https://img.shields.io/badge/AppVersion-41.46.3-informational?style=flat-square)
+![Version: 42.0.0](https://img.shields.io/badge/Version-42.0.0-informational?style=flat-square) ![AppVersion: 41.46.3](https://img.shields.io/badge/AppVersion-41.46.3-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
 | image.tag | string | `"41.46.3"` | Renovate image tag to pull |
-| image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
+| image.useFull | bool | `false` | Set `true` to use the full image. See <https://docs.renovatebot.com/getting-started/running/#the-full-image> |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` | Select the node using labels to specify where the cronjob pod should run on |
@@ -125,7 +125,7 @@ can make use of the cache that have been build up in previous runs. Set `renovat
 to enable this. If necessary, the storageClass can be configured and the storageSize can be set to the preferred value.
 
 **HINT**: It is highly recommended to use the redis subchart or SQLite for caching, instead of disk caching.
-Take a look at https://github.com/renovatebot/renovate/discussions/30525 for more information.
+Take a look at <https://github.com/renovatebot/renovate/discussions/30525> for more information.
 
 ## Renovate config templating
 

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -125,7 +125,7 @@ can make use of the cache that have been build up in previous runs. Set `renovat
 to enable this. If necessary, the storageClass can be configured and the storageSize can be set to the preferred value.
 
 **HINT**: It is highly recommended to use the redis subchart or SQLite for caching, instead of disk caching.
-Take a look at <https://github.com/renovatebot/renovate/discussions/30525> for more information.
+Take a look at https://github.com/renovatebot/renovate/discussions/30525 for more information.
 
 ## Renovate config templating
 

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the chart and the defau
 | image.registry | string | `"ghcr.io"` | Registry to pull image from |
 | image.repository | string | `"renovatebot/renovate"` | Image name to pull |
 | image.tag | string | `"41.46.3"` | Renovate image tag to pull |
-| image.useFull | bool | `false` | Set `true` to use the full image. See <https://docs.renovatebot.com/getting-started/running/#the-full-image> |
+| image.useFull | bool | `false` | Set `true` to use the full image. See https://docs.renovatebot.com/getting-started/running/#the-full-image |
 | imagePullSecrets | object | `{}` | Secret to use to pull the image from the repository |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` | Select the node using labels to specify where the cronjob pod should run on |

--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,8 @@
       "description": "Update renovate docker image references",
       "managerFilePatterns": ["charts/renovate/Chart.yaml"],
       "matchStrings": [
-        "appVersion: '(?<currentValue>.*?)'\\s+",
-        "version: '(?<currentValue>.*?)'\\s+",
-        "(?:image|name): (?<depName>.*?):(?<currentValue>.*?)\\s+"
+        "appVersion:\\s+(?<currentValue>[^\\s]+)",
+        "(?:image|name): (?<depName>.*?):(?<currentValue>[^\\s]+)"
       ],
       "depNameTemplate": "{{#if depName}}{{depName}}{{else}}ghcr.io/renovatebot/renovate{{/if}}",
       "datasourceTemplate": "docker"
@@ -24,7 +23,7 @@
       "managerFilePatterns": ["charts/renovate/README.md"],
       "matchStrings": [
         "\\|\\s+image.tag\\s+\\|\\s+string\\s+\\|\\s+`\"(?<currentValue>.*?)\"`\\s+\\|\\s+",
-        "(:\\s|-)(?<currentValue>\\d+\\.\\d+\\.\\d+(?:\\+\\d+)?)"
+        "AppVersion(?::\\s|-)(?<currentValue>\\d+\\.\\d+\\.\\d+(?:\\+\\d+)?)"
       ],
       "depNameTemplate": "ghcr.io/renovatebot/renovate",
       "datasourceTemplate": "docker"
@@ -93,6 +92,28 @@
       "matchDepNames": ["azure/setup-helm"],
       "extractVersion": "^(?<version>.+)$",
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?)?$"
+    },
+    {
+      "matchFileNames": ["charts/**"],
+      "bumpVersions": [
+        {
+          "filePatterns": ["{{packageFileDir}}/Chart.{yaml,yml}"],
+          "matchStrings": ["version:\\s(?<version>[^\\s]+)"],
+          "bumpType": "{{#if isPatch}}patch{{else}}{{#if isMajor}}major{{else}}minor{{/if}}{{/if}}"
+        }
+      ]
+    },
+    {
+      "matchFileNames": ["charts/**"],
+      "bumpVersions": [
+        {
+          "filePatterns": ["{{packageFileDir}}/README.md"],
+          "matchStrings": [
+            "(?:\\[|\\/])Version(?::\\s|-)(?<version>\\d+\\.\\d+\\.\\d+)"
+          ],
+          "bumpType": "{{#if isPatch}}patch{{else}}{{#if isMajor}}major{{else}}minor{{/if}}{{/if}}"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- let renovate bump the chart version with `bumpVersions`
- do no longer keep app version and chart version in sync

- closes #54