### PR TITLE
ci: add yamale version to fix CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
         with:
           version: v3.14.0 # renovate: datasource=github-releases depName=chart-testing packageName=helm/chart-testing
+          yamale_version: 6.0.0 # renovate: datasource=github-releases depName=yamale packageName=23andMe/Yamale
 
       - name: Run lint
         run: ct lint --config .github/ct.yaml


### PR DESCRIPTION
As noted in [0], we are currently seeing GitHub Actions failing to run
Helm Chart validation since #3329 was merged.

As noted by [1], the current workaround for this failure is to ensure we
pull a newer version of `yamale`.

Additionally, we'll add the required Renovate notation to keep this
version update.

[0]: https://github.com/helm/chart-testing/issues/780
[1]: https://github.com/helm/chart-testing-action/issues/177#issuecomment-3386841674
