### PR TITLE
chore(renovate): ignore weekly docs update presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
     "local>renovatebot/.github",
     "local>renovatebot/.github//merge-queue.json"
   ],
+  "ignorePresets": [
+    "local>renovatebot/.github:weekly-docs-references"
+  ],
   "assignees": ["viceice"],
   "customManagers": [
     {


### PR DESCRIPTION
As found in https://github.com/renovatebot/helm-charts/pull/3360, we're
missing out on some changes due to this rule.

By ignoring the preset, we can now correctly update all references in
one branch.
