### PR TITLE
fix: extraConfigmaps support

### DIFF
--- a/charts/renovate/Chart.yaml
+++ b/charts/renovate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 42.10.2
 description: Universal dependency update tool that fits into your workflows.
 name: renovate
-version: 45.8.1
+version: 45.8.2
 icon: https://docs.renovatebot.com/assets/images/logo.png
 home: https://github.com/renovatebot/renovate
 keywords:

--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -1,6 +1,6 @@
 # renovate
 
-![Version: 45.8.1](https://img.shields.io/badge/Version-45.8.1-informational?style=flat-square) ![AppVersion: 42.10.2](https://img.shields.io/badge/AppVersion-42.10.2-informational?style=flat-square)
+![Version: 45.8.2](https://img.shields.io/badge/Version-45.8.2-informational?style=flat-square) ![AppVersion: 42.10.2](https://img.shields.io/badge/AppVersion-42.10.2-informational?style=flat-square)
 
 Universal dependency update tool that fits into your workflows.
 

--- a/charts/renovate/templates/extra-configmap.yaml
+++ b/charts/renovate/templates/extra-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "renovate.fullname" $ }}-extra-{{ .name }}
-  namespace: {{ include "renovate.namespace" . }}
+  namespace: {{ include "renovate.namespace" $ }}
   labels:
     {{- include "renovate.labels" $ | nindent 4 }}
 data:


### PR DESCRIPTION
This was broken by #2666. Inside the `range` loop, `.` refers to the current configmap item, not the root context. This causes an error when installing:
```sh
$ helm install -n renovate renovate renovate/renovate -f values.yaml
Error: INSTALLATION FAILED: template: renovate/templates/extra-configmap.yaml:7:16: executing "renovate/templates/extra-configmap.yaml" at <include "renovate.namespace" .>: error calling include: template: renovate/templates/_helpers.tpl:14:20: executing "renovate.namespace" at <.Release.Namespace>: nil pointer evaluating interface {}.Namespace
```