### PR TITLE
ci: use k3s instead of kind

### DIFF
--- a/.github/actions/setup-k3s/action.yml
+++ b/.github/actions/setup-k3s/action.yml
@@ -13,7 +13,7 @@ runs:
     - shell: bash
       name: install k3s
       run: |
-        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${INPUT_VERSION} K3S_KUBECONFIG_MODE=640 sudo sh -s - server
+        curl -sfL https://get.k3s.io | sudo INSTALL_K3S_VERSION=${INPUT_VERSION} K3S_KUBECONFIG_MODE=640 sh -s - server
         echo "KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> $GITHUB_ENV
     - shell: bash
       name: check k3s

--- a/.github/actions/setup-k3s/action.yml
+++ b/.github/actions/setup-k3s/action.yml
@@ -1,0 +1,25 @@
+# action.yml
+name: setup-k3s
+description: 'setup k3s'
+
+inputs:
+  version:
+    description: 'k3s version'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      name: install k3s
+      run: |
+        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${INPUT_VERSION} K3S_KUBECONFIG_MODE=640 sudo sh -s - server
+        echo "KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> $GITHUB_ENV
+    - shell: bash
+      name: check k3s
+      run: kubectl cluster-info
+    - shell: bash
+      name: wait for nodes ready
+      run: |
+        sleep 3
+        kubectl wait --for=condition=Ready nodes --all --timeout=600s

--- a/.github/actions/setup-k3s/action.yml
+++ b/.github/actions/setup-k3s/action.yml
@@ -13,7 +13,7 @@ runs:
     - shell: bash
       name: install k3s
       run: |
-        curl -sfL https://get.k3s.io | sudo INSTALL_K3S_VERSION=${INPUT_VERSION} K3S_KUBECONFIG_MODE=640 sh -s - server
+        curl -sfL https://get.k3s.io | sudo INSTALL_K3S_VERSION=${INPUT_VERSION} K3S_KUBECONFIG_MODE=644 sh -s - server
         echo "KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> $GITHUB_ENV
     - shell: bash
       name: check k3s

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>renovatebot/.github",
-    "local>renovatebot/.github//merge-queue.json"
+    "github>renovatebot/.github",
+    "github>renovatebot/.github//merge-queue.json",
+    "github>renovatebot/helm-charts//.github/renovate/k3s.json"
   ],
   "assignees": ["viceice"],
   "customManagers": [
@@ -37,6 +38,15 @@
       ],
       "depNameTemplate": "kindest/node",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Update k3s kubernetes references",
+      "managerFilePatterns": [".github/workflows/*.y{,a}ml"],
+      "matchStrings": [" +- (?<currentValue>.+?) # renovate: k3s\\n"],
+      "depNameTemplate": "k3s",
+      "packageNameTemplate": "k3s-io/k3s",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [
@@ -72,10 +82,7 @@
     },
     {
       "description": "Use fix semantic commit scope for renovate updates",
-      "matchDepNames": [
-        "renovate/renovate",
-        "ghcr.io/renovatebot/renovate"
-      ],
+      "matchDepNames": ["renovate/renovate", "ghcr.io/renovatebot/renovate"],
       "semanticCommitType": "fix",
       "semanticCommitScope": null
     },

--- a/.github/renovate/k3s.json
+++ b/.github/renovate/k3s.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Separate minor and patch updates for k3s",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["k3s-io/k3s"],
+      "separateMultipleMinor": true,
+      "separateMinorPatch": true,
+      "branchTopic": "{{{depNameSanitized}}}{{#if isMinor}}-minor{{/if}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}",
+      "commitMessageSuffix": "{{#if isMinor}}(minor){{/if}}{{#if isPatch}}(patch){{/if}}"
+    },
+    {
+      "description": "No automerge for k3s major and minor updates",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["k3s-io/k3s"],
+      "matchUpdateTypes": ["major", "minor"],
+      "automerge": false
+    },
+    {
+      "description": "Group k3s patch updates",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["k3s-io/k3s"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "k3s"
+    },
+    {
+      "description": "Disable k3s major and minor updates for old versions",
+      "matchDatasources": ["github-releases"],
+      "matchFileNames": [".github/workflows/**"],
+      "matchPackageNames": ["k3s-io/k3s"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchCurrentValue": "!/^v1.36/",
+      "enabled": false
+    }
+  ],
+  "customDatasources": {
+    "k3s": {
+      "defaultRegistryUrlTemplate": "https://update.k3s.io/v1-release/channels",
+      "transformTemplates": [
+        "($isVersion:=function($name){$contains($name,/^v\\d+.\\d+$/)};{\"releases\":[data[$isVersion(name)].{\"version\":latest}],\"sourceUrl\":\"https://github.com/k3s-io/k3s\",\"homepage\":\"https://k3s.io/\"})"
+      ]
+    }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [".github/renovate/k3s.json"],
+      "matchStrings": [
+        "matchCurrentValue\": \"!\\/\\^v(?<currentValue>\\d+\\.\\d+)\\/"
+      ],
+      "depNameTemplate": "k3s",
+      "versioningTemplate": "npm",
+      "datasourceTemplate": "custom.k3s"
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,8 +95,7 @@ jobs:
           # https://github.com/k3s-io/k3s/branches
           # oldest supported version
           - v1.31.14+k3s1 # renovate: k3s
-          - v1.32.13+k3s1 # renovate: k3s
-          - v1.33.11+k3s1 # renovate: k3s
+          # oldstable version
           - v1.34.7+k3s1 # renovate: k3s
           # https://github.com/k3s-io/k3s/blob/master/channel.yaml#L3-L4
           # stable version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,24 +86,33 @@ jobs:
       - kubeconform-chart
     strategy:
       matrix:
-        k8s:
-          # from https://hub.docker.com/r/kindest/node/tags
-          - v1.31.14 # renovate: kindest
-          - v1.32.11 # renovate: kindest
-          - v1.33.7 # renovate: kindest
-          - v1.34.3 # renovate: kindest
-          - v1.35.1 # renovate: kindest
+        # k8s:
+        #   # from https://hub.docker.com/r/kindest/node/tags
+        #   - v1.30.13 # renovate: kindest
+        #   - v1.31.14 # renovate: kindest
+        #   - v1.32.11 # renovate: kindest
+        #   - v1.33.7 # renovate: kindest
+        #   - v1.34.3 # renovate: kindest
+        k3s:
+          # https://github.com/k3s-io/k3s/branches
+          # oldest supported version
+          - v1.28.15+k3s1 # renovate: k3s
+          # https://github.com/k3s-io/k3s/blob/master/channel.yaml#L3-L4
+          # stable version
+          - v1.34.7+k3s1 # renovate: k3s
+          # newest version
+          - v1.35.4+k3s1 # renovate: k3s
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          show-progress: false
           fetch-depth: 0
+          filter: blob:none # We don't need all blobs
 
-      - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+      - uses: ./.github/actions/setup-k3s
         with:
-          node_image: kindest/node:${{ matrix.k8s }}
-          version: v0.31.0 # renovate: datasource=github-releases depName=kind packageName=kubernetes-sigs/kind
+          version: ${{ matrix.k3s }}
 
       - name: Install chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          show-progress: false
           fetch-depth: 0
 
       - name: Install Helm
@@ -46,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          show-progress: false
       - name: Run helm-docs
         run: .github/helm-docs.sh
 
@@ -69,6 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          show-progress: false
           fetch-depth: 0
 
       - name: Run kubeconform

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,22 +90,19 @@ jobs:
       - kubeconform-chart
     strategy:
       matrix:
-        # k8s:
-        #   # from https://hub.docker.com/r/kindest/node/tags
-        #   - v1.30.13 # renovate: kindest
-        #   - v1.31.14 # renovate: kindest
-        #   - v1.32.11 # renovate: kindest
-        #   - v1.33.7 # renovate: kindest
-        #   - v1.34.3 # renovate: kindest
         k3s:
+          # https://github.com/renovatebot/helm-charts/issues/579
           # https://github.com/k3s-io/k3s/branches
           # oldest supported version
-          - v1.28.15+k3s1 # renovate: k3s
+          - v1.31.14+k3s1 # renovate: k3s
+          - v1.32.13+k3s1 # renovate: k3s
+          - v1.33.11+k3s1 # renovate: k3s
+          - v1.34.7+k3s1 # renovate: k3s
           # https://github.com/k3s-io/k3s/blob/master/channel.yaml#L3-L4
           # stable version
-          - v1.34.7+k3s1 # renovate: k3s
-          # newest version
           - v1.35.4+k3s1 # renovate: k3s
+          # latest version
+          - v1.36.0+k3s1 # renovate: k3s
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
- #579
- kind doesn't have k8s v1.36 and is slow on other updates 
- k3s is faster in install and runtime (no k8s in docker)