### PR TITLE
feat: add CronJob pod DNS settings

### DIFF
--- a/charts/renovate/README.md
+++ b/charts/renovate/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the chart and the defau
 | cronjob.suspend | bool | `false` | If it is set to true, all subsequent executions are suspended. This setting does not apply to already started executions. |
 | cronjob.timeZone | string | `""` | You can specify a time zone for a CronJob by setting timeZone to the name of a valid time zone. (starting with k8s 1.27) <https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones> |
 | cronjob.ttlSecondsAfterFinished | string | `""` | Time to keep the job after it finished before automatically deleting it |
+| dnsConfig | object | `{}` | Configure pod DNS settings |
+| dnsPolicy | string | `""` | Configure pod DNS policy |
 | env | object | `{}` | Environment variables to set on the renovate container |
 | envFrom | list | `[]` | Environment variables to add from existing secrets/configmaps. Uses the keys as variable name |
 | envList | list | `[]` | Additional env. Helpful too if you want to use anything other than a `value` source. |

--- a/charts/renovate/ci/ci-values.yaml
+++ b/charts/renovate/ci/ci-values.yaml
@@ -29,3 +29,8 @@ hostAliases:
   - ip: "1.2.3.4"
     hostnames:
       - "example.com"
+dnsPolicy: ClusterFirst
+dnsConfig:
+  options:
+    - name: ndots
+      value: "1"

--- a/charts/renovate/templates/cronjob.yaml
+++ b/charts/renovate/templates/cronjob.yaml
@@ -85,6 +85,13 @@ spec:
           hostAliases:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.dnsPolicy }}
+          dnsPolicy: {{ . }}
+        {{- end }}
+        {{- with .Values.dnsConfig }}
+          dnsConfig:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           {{- if or .Values.cronjob.initContainers .Values.ssh_config.enabled }}
           initContainers:
             {{- if .Values.ssh_config.enabled }}

--- a/charts/renovate/values.yaml
+++ b/charts/renovate/values.yaml
@@ -258,6 +258,12 @@ hostAliases: []
 #     hostnames:
 #       - "your-hostname"
 
+# -- Configure pod DNS settings
+dnsConfig: {}
+
+# -- Configure pod DNS policy
+dnsPolicy: ''
+
 # -- Pod-level security-context
 securityContext: {}
 


### PR DESCRIPTION
## Summary

- expose optional `dnsConfig` and `dnsPolicy` values for CronJob pods
- render both fields in the pod spec
- document the values and exercise them in the existing CI fixture

Closes #3861

## Compatibility

Both values default to empty and are omitted from rendered manifests, so existing installations are unchanged.

## Validation

- generated values documentation updated
- existing CI values cover `ClusterFirst` and a lower `ndots` option
- repository CI will run chart lint, documentation drift checks, and kubeconform
